### PR TITLE
Feature/pruebas s1 espresso

### DIFF
--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -1,0 +1,284 @@
+# Pruebas E2E — Vinilos
+
+Documento de referencia para las pruebas end-to-end de la app Vinilos.
+
+---
+
+## 1. Alcance
+
+Las pruebas E2E (`app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt`) atacan **`MainActivity` real** con **Hilt** arrancado, y consumen el **backend de Vinilos** levantado localmente vía docker-compose. No usan fakes ni mocks — validan la integración completa: UI → ViewModel → UseCase → Repositorio → Retrofit → backend → Room.
+
+Cobertura: features **Álbumes**, **Artistas** y **navegación entre tabs**.
+
+---
+
+## 2. Stack de pruebas
+
+| Componente | Librería |
+|---|---|
+| Framework E2E | Jetpack Compose Test (`androidx.compose.ui:ui-test-junit4`) |
+| Instrumentación | `androidx.test:runner 1.6.2` |
+| DI en tests | `com.google.dagger:hilt-android-testing` |
+| Runner custom | `com.misw4203.vinilos.HiltTestRunner` (arranca `HiltTestApplication`) |
+| Back del sistema | `androidx.test.espresso.Espresso.pressBack()` |
+| Backend | `backvynils-web-1` (docker) en `http://10.0.2.2:3000` |
+
+---
+
+## 3. Requisitos para ejecutar
+
+1. **Emulador Android API 33 o 34**.
+   - API 35+ rompe Espresso 3.6.1 con `NoSuchMethodException: android.hardware.input.InputManager.getInstance`. Hasta que `espresso-core` stable lo soporte, usar Pixel 7/8 con Android 14 (API 34).
+2. **Backend docker corriendo**:
+   ```bash
+   docker compose up -d
+   # Verificar:
+   curl http://localhost:3000/albums
+   ```
+   - `backvynils-db-1` (postgres:16) en puerto 5432.
+   - `backvynils-web-1` en puerto 3000.
+3. **Semilla del backend**: al menos 1 álbum y 1 artista. El set por defecto trae 4 álbumes (IDs 100–103) y 1 artista (ID 100).
+
+### Ejecución
+
+```bash
+# Todas las pruebas instrumentadas (incluye E2E + tests de componente)
+./gradlew connectedAndroidTest
+
+# Un test E2E específico
+./gradlew connectedAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=\
+com.misw4203.vinilos.e2e.VinilosE2ETest#albumList_rendersListFromBackend
+```
+
+Reporte HTML: `app/build/reports/androidTests/connected/debug/index.html`.
+
+---
+
+## 4. Infraestructura añadida al proyecto
+
+### `HiltTestRunner`
+```kotlin
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, className: String?, context: Context?) =
+        super.newApplication(cl, HiltTestApplication::class.java.name, context)
+}
+```
+
+Configurado en `app/build.gradle.kts`:
+```kotlin
+testInstrumentationRunner = "com.misw4203.vinilos.HiltTestRunner"
+```
+
+### Deps añadidas en `libs.versions.toml`
+```toml
+androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.6.2" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+```
+
+### `testTag`s agregados al código de producción
+| Composable | Tag |
+|---|---|
+| `AlbumListScreen` → `LazyColumn` | `albums_list` |
+| `AlbumCard` (wrapper en lista) | `album_card_{id}` |
+| `MusicianListScreen` → `LazyColumn` | `artists_list` |
+| `MusicianCard` (wrapper en lista) | `musician_card_{id}` |
+| `VinilosBottomNav` tabs | `bottom_nav_albums`, `bottom_nav_artists`, `bottom_nav_collectors` |
+| `AlbumDetailScreen` root | `album_detail_root` |
+| `AlbumDetailScreen` back btn | `album_detail_back` |
+| `MusicianDetailScreen` body | `artist_detail_root` |
+| `MusicianDetailScreen` back btn | `artist_detail_back` |
+| `PrizeItem` en detalle de artista | `prize_{id}` |
+
+---
+
+## 5. Escenarios cubiertos
+
+### Álbumes — lista y detalle
+| ID | Escenario | Cobertura |
+|---|---|---|
+| AL-01 | Dado el backend con álbumes, la pantalla principal muestra la lista. | ✅ E2E |
+| AL-05 | Dado que la lista está cargada, al tocar una card el usuario aterriza en el detalle. | ✅ E2E |
+| AD-01 | Dado un álbum abierto, se muestra su detalle (imagen, título, metadatos). | ✅ E2E |
+| AD-02 | Dado el detalle abierto, al tocar "back" vuelve a la lista. | ✅ E2E |
+| AD-05 | Dado un álbum con comentarios, el rating expone `contentDescription` accesible (TalkBack anuncia "N de 5 estrellas"). | ✅ E2E |
+
+### Artistas — lista y detalle
+| ID | Escenario | Cobertura |
+|---|---|---|
+| ML-01 | Dado el backend con artistas, al cambiar al tab "Artists" se muestra la lista. | ✅ E2E |
+| ML-04 | Dado el listado de artistas, al tocar una card se abre el detalle. | ✅ E2E |
+| MD-01 | Dado un artista abierto, se muestra su detalle. | ✅ E2E |
+| MD-04 | Dado el detalle abierto, al tocar "back" vuelve a la lista de artistas. | ✅ E2E |
+
+### Navegación
+| ID | Escenario | Cobertura |
+|---|---|---|
+| NAV-01 | Dado estar en un tab, al tocar otro en la bottom nav cambia la pantalla y el título. | ✅ E2E |
+| NAV-03 | Dado estar en un detalle, el botón back del sistema regresa a la lista. | ✅ E2E |
+
+### Escenarios NO cubiertos por E2E (y dónde sí están)
+| ID | Escenario | Motivo de exclusión E2E | Cobertura alterna |
+|---|---|---|---|
+| AL-02, ML-02 | Empty state | No se puede forzar lista vacía en backend real | Unit tests de VM |
+| AL-03, AL-04, AL-06, AD-03, AD-04, ML-03 | Error state (red/servidor) + retry | No se puede inyectar `IOException` / HTTP 500 sin apagar docker mid-test | Unit tests de VM y repo |
+| AD-03, MD-05 | NotFound (404) | Requiere deep-link a ID inexistente; la nav no expone args de test | Unit tests de VM |
+| MD-02, MD-03 | AlertDialog de premios | La semilla actual no confirma performerPrizes en el artista base | Fácil de añadir si se garantiza dataset |
+
+---
+
+## 6. Casos de prueba detallados
+
+### 6.1 `albumList_rendersListFromBackend` — AL-01
+
+**Objetivo**: verificar que la pantalla inicial carga álbumes del backend.
+
+**Precondiciones**: backend up con ≥1 álbum.
+
+**Pasos**:
+1. Esperar hasta que exista un nodo con `testTag("albums_list")` (timeout 10s).
+
+**Validaciones**:
+- `onNodeWithTag("albums_list").assertIsDisplayed()`.
+
+---
+
+### 6.2 `albumList_tapFirstCard_opensDetail_andBackReturns` — AL-05, AD-01, AD-02
+
+**Objetivo**: flujo completo lista → detalle → regreso.
+
+**Precondiciones**: backend up con ≥1 álbum.
+
+**Pasos**:
+1. Esperar a `albums_list`.
+2. Scroll al primer nodo cuyo `TestTag` empiece por `album_card_` (SemanticsMatcher custom).
+3. Click sobre ese nodo.
+4. Esperar a `album_detail_root`.
+5. Click en `album_detail_back`.
+6. Esperar a `albums_list` nuevamente.
+
+**Validaciones**:
+- `album_detail_root` visible tras el click (navegación efectiva).
+- `albums_list` visible tras el back.
+
+---
+
+### 6.3 `artistList_rendersListFromBackend` — ML-01
+
+**Objetivo**: el tab "Artists" carga el listado de artistas.
+
+**Precondiciones**: backend up con ≥1 artista.
+
+**Pasos**:
+1. Click en `bottom_nav_artists`.
+2. Esperar a `artists_list`.
+
+**Validaciones**:
+- `artists_list` visible.
+
+---
+
+### 6.4 `artistList_tapFirstCard_opensDetail_andBackReturns` — ML-04, MD-01, MD-04
+
+**Objetivo**: flujo lista de artistas → detalle → back.
+
+**Pasos**:
+1. Click en `bottom_nav_artists`.
+2. Esperar a `artists_list`.
+3. Click en primer nodo con tag que empieza por `musician_card_`.
+4. Esperar a `artist_detail_root`.
+5. Click en `artist_detail_back`.
+6. Esperar a `artists_list`.
+
+**Validaciones**:
+- `artist_detail_root` visible tras el click.
+- `artists_list` visible tras el back.
+
+---
+
+### 6.5 `bottomNav_switchesBetweenTabs` — NAV-01
+
+**Objetivo**: la bottom nav cambia entre Albums ↔ Artists y el top bar refleja el cambio.
+
+**Pasos**:
+1. Esperar a `albums_list`; verificar que el título "Albums" esté visible.
+2. Click en `bottom_nav_artists`; esperar al texto del título "Artists".
+3. Click en `bottom_nav_albums`; esperar a `albums_list`.
+
+**Validaciones**:
+- Tras cada switch, el título correcto (`albums_title` / `artists_title`) está `isDisplayed`.
+
+---
+
+### 6.6 `systemBack_fromAlbumDetail_returnsToList` — NAV-03
+
+**Objetivo**: el back del sistema operativo (gesto/botón) regresa al listado desde el detalle.
+
+**Pasos**:
+1. Esperar a `albums_list`, scroll y click en primer `album_card_*`.
+2. Esperar a `album_detail_root`.
+3. `Espresso.pressBack()`.
+4. Esperar a `albums_list`.
+
+**Validaciones**:
+- `albums_list` visible nuevamente.
+
+---
+
+### 6.7 `albumDetail_ratingHasAccessibleContentDescription_ifCommentsPresent` — AD-05
+
+**Objetivo**: accesibilidad — los ratings de comentarios exponen `contentDescription` legible por TalkBack ("N de 5 estrellas").
+
+**Precondiciones**: el primer álbum del backend tiene ≥1 comentario.
+
+**Pasos**:
+1. Esperar a `albums_list`, scroll y click en el primer `album_card_*`.
+2. Esperar a `album_detail_root`.
+3. Buscar nodos cuyo `contentDescription` contenga `"de 5"` (substring match).
+4. Si la lista viene vacía, el test es no-op (el álbum no tiene comentarios).
+
+**Validaciones**:
+- Primer nodo encontrado debe existir (`assertExists`, **no** `assertIsDisplayed` — el nodo puede estar fuera del viewport pero seguir siendo anunciado por TalkBack al hacer scroll).
+
+---
+
+## 7. Matchers y helpers personalizados
+
+### `tagStartsWith(prefix: String): SemanticsMatcher`
+Evita acoplar los tests a los IDs sembrados por el backend.
+```kotlin
+private fun tagStartsWith(prefix: String): SemanticsMatcher =
+    SemanticsMatcher("TestTag starts with '$prefix'") { node ->
+        val tag = node.config.getOrNull(SemanticsProperties.TestTag) ?: return@SemanticsMatcher false
+        tag.startsWith(prefix)
+    }
+```
+
+Uso:
+```kotlin
+val firstCard = tagStartsWith("album_card_")
+composeRule.onNodeWithTag("albums_list").performScrollToNode(firstCard)
+composeRule.onAllNodes(firstCard)[0].performClick()
+```
+
+### `waitForTag(tag: String)` / `waitForText(text: String)`
+Bloquean hasta que el nodo aparece en el semantic tree (timeout 10s). Necesarios porque los `StateFlow` pasan de `Loading → Success` asíncronamente con la red.
+
+---
+
+## 8. Lecciones aprendidas durante la implementación
+
+1. **Compose ≠ Espresso clásico.** El brief original pedía `onView(withId(...))`, pero el proyecto es 100% Compose. La API correcta es `onNodeWithTag/Text/ContentDescription` + `SemanticsMatcher`. Espresso clásico no aplica salvo para `pressBack()`.
+2. **Espresso 3.6.1 + API 35+ = crash.** `InputManager.getInstance()` fue removido en API 34; Espresso aún lo reflexiona. Workaround: emulador API 33/34 hasta que salga una versión stable de `espresso-core` compatible.
+3. **IDs hardcodeados son frágiles.** Primer intento iteraba `album_card_1..50`, pero el backend siembra IDs 100–103. Solución: `SemanticsMatcher` con `startsWith`.
+4. **`assertIsDisplayed()` es estricto con viewport.** Para accesibilidad o para verificar que un nodo está en el tree, `assertExists()` es más correcto. TalkBack anuncia nodos aunque no estén en pantalla si el usuario hace scroll hacia ellos.
+5. **Network-first + cache puede enmascarar escenarios offline.** La primera vez que un test corre, la caché está vacía; tests subsecuentes pueden ver la caché aunque el backend esté abajo. Aceptable para esta suite (no testea offline), pero relevante si se añaden escenarios de error.
+
+---
+
+## 9. Siguientes pasos (propuestos, no implementados)
+
+- **MockWebServer + `@UninstallModules(NetworkModule)`**: habilita escenarios de Error (AL-03/04, AD-03/04, ML-03) y NotFound (AD-03, MD-05) sin depender de apagar docker.
+- **Dataset seed determinista**: endpoint o script que garantice comentarios y prizes para estabilizar AD-05 y MD-02/03.
+- **Screenshot testing (Paparazzi/Roborazzi)**: regressions visuales de cards, top bar, bottom nav. Costo: plugin adicional y PNGs en repo.
+- **CI**: ejecutar `connectedAndroidTest` en GitHub Actions con emulador API 34 y `docker compose up` previo.

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Módulos de Hilt instalados en `SingletonComponent`.
 |---|---|---|
 | `app/src/test/` | Unit tests JVM | JUnit 4, MockK, Turbine, `kotlinx-coroutines-test` |
 | `app/src/androidTest/` | Compose UI tests (instrumentados) | `ui-test-junit4`, `ui-test-manifest`, `hilt-android-testing` |
-| `app/src/androidTest/.../e2e/` | Pruebas E2E contra `MainActivity` real y backend | Compose Test + Hilt + backend docker local |
+| `app/src/androidTest/.../e2e/` | Pruebas E2E contra `MainActivity` real con datos fake | Compose Test + Hilt + `FakeRepositoryModule` |
 
 **Convenciones**:
 - ViewModel tests usan **fake repos inline** (clases anidadas que implementan la interfaz) para control explícito de resultados y conteo de llamadas.
 - Repository tests usan **MockK** sobre `VinilosApiService` y los DAOs.
 - Use-case tests mockean el repositorio y verifican delegación.
 - Compose UI tests de componentes reciben el VM como parámetro (los screens aceptan `viewModel: VM = hiltViewModel()` con default), evitando montar Hilt.
-- **Tests E2E** (`VinilosE2ETest`): atacan `MainActivity` real, arrancan Hilt con `HiltTestApplication`, y asumen backend corriendo en `http://10.0.2.2:3000`. Ver [`E2E_TESTS.md`](./E2E_TESTS.md).
+- **Tests E2E** (`VinilosE2ETest`): atacan `MainActivity` real con Hilt. Un módulo `@TestInstallIn` (`FakeRepositoryModule`) reemplaza los repositorios de producción por implementaciones en memoria, por lo que **no requieren backend ni Docker**. Solo necesitan el emulador.
 
 ---
 
@@ -150,7 +150,7 @@ Módulos de Hilt instalados en `SingletonComponent`.
 # Tests instrumentados (requiere emulador/dispositivo)
 # IMPORTANTE: usar emulador API 33 o 34. API 35+ rompe Espresso 3.6.1
 # (NoSuchMethodException: InputManager.getInstance).
-# Los E2E además requieren backend docker-compose up en puertos 3000 y 5432.
+# No se requiere backend ni Docker — los repositorios están reemplazados por fakes.
 ./gradlew connectedAndroidTest
 
 # Solo compilar tests instrumentados (sin ejecutar)

--- a/README.md
+++ b/README.md
@@ -122,13 +122,15 @@ Módulos de Hilt instalados en `SingletonComponent`.
 | Ubicación | Tipo | Herramientas |
 |---|---|---|
 | `app/src/test/` | Unit tests JVM | JUnit 4, MockK, Turbine, `kotlinx-coroutines-test` |
-| `app/src/androidTest/` | Compose UI tests (instrumentados) | `ui-test-junit4`, `ui-test-manifest` |
+| `app/src/androidTest/` | Compose UI tests (instrumentados) | `ui-test-junit4`, `ui-test-manifest`, `hilt-android-testing` |
+| `app/src/androidTest/.../e2e/` | Pruebas E2E contra `MainActivity` real y backend | Compose Test + Hilt + backend docker local |
 
 **Convenciones**:
 - ViewModel tests usan **fake repos inline** (clases anidadas que implementan la interfaz) para control explícito de resultados y conteo de llamadas.
 - Repository tests usan **MockK** sobre `VinilosApiService` y los DAOs.
 - Use-case tests mockean el repositorio y verifican delegación.
-- Compose UI tests reciben el VM como parámetro (los screens aceptan `viewModel: VM = hiltViewModel()` con default), evitando montar Hilt en tests.
+- Compose UI tests de componentes reciben el VM como parámetro (los screens aceptan `viewModel: VM = hiltViewModel()` con default), evitando montar Hilt.
+- **Tests E2E** (`VinilosE2ETest`): atacan `MainActivity` real, arrancan Hilt con `HiltTestApplication`, y asumen backend corriendo en `http://10.0.2.2:3000`. Ver [`E2E_TESTS.md`](./E2E_TESTS.md).
 
 ---
 
@@ -146,6 +148,9 @@ Módulos de Hilt instalados en `SingletonComponent`.
 ./gradlew test
 
 # Tests instrumentados (requiere emulador/dispositivo)
+# IMPORTANTE: usar emulador API 33 o 34. API 35+ rompe Espresso 3.6.1
+# (NoSuchMethodException: InputManager.getInstance).
+# Los E2E además requieren backend docker-compose up en puertos 3000 y 5432.
 ./gradlew connectedAndroidTest
 
 # Solo compilar tests instrumentados (sin ejecutar)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ app/src/main/java/com/misw4203/vinilos/
 │   └── ui/
 │       ├── screens/
 │       │   ├── album/
-│       │   ├── artist/
-│       │   └── collector/
+│       │   └── artist/
 │       ├── components/  # Composables reutilizables
 │       └── theme/       # Material 3 theme
 └── di/                  # Módulos de Hilt
@@ -49,7 +48,7 @@ Responsable de obtener y persistir datos, ya sea desde la red o desde la base de
 | `data/local/dao/` | Interfaces DAO de Room con operaciones `@Upsert`, `@Query`, y transacciones (`replaceX` = clear + upsert). |
 | `data/local/database/` | `VinilosDatabase` — clase abstracta `RoomDatabase` que declara entidades y expone los DAOs. |
 | `data/local/entity/` | Entidades `@Entity` con mappers `toDomain()` / `fromDomain()`. |
-| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints (`GET /albums`, `GET /musicians`, `GET /collectors`, etc.). |
+| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints (`GET /albums`, `GET /albums/{id}`, `GET /musicians`, `GET /musicians/{id}`, `GET /prizes/{id}`). |
 | `data/remote/dto/` | DTOs que modelan la respuesta JSON. Campos nullables para tolerar datos incompletos del servidor. |
 | `data/repository/` | Implementaciones de repositorio con estrategia **network-first + fallback a caché**. |
 
@@ -69,9 +68,9 @@ Es el núcleo de la aplicación. No depende de ninguna otra capa y contiene la l
 
 | Carpeta | Contenido |
 |---|---|
-| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `Collector`, `CollectorSummary`, `FavoritePerformer`, `MusicianPrize`, etc.). Sin dependencias de Android. |
-| `domain/repository/` | Interfaces de repositorio (`AlbumRepository`, `MusicianRepository`, `CollectorRepository`). |
-| `domain/usecase/` | Casos de uso (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`, `GetCollectorsUseCase`, `GetCollectorDetailUseCase`). |
+| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `MusicianPrize`, `Track`, `Performer`, `Comment`). Sin dependencias de Android. |
+| `domain/repository/` | Interfaces de repositorio (`AlbumRepository`, `MusicianRepository`). |
+| `domain/usecase/` | Casos de uso (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`). |
 
 ---
 
@@ -83,8 +82,8 @@ Contiene todo lo relacionado con la interfaz de usuario y el estado de la pantal
 |---|---|
 | `presentation/navigation/` | `VinilosNavHost` + `Destinations` (rutas y argumentos de navegación). |
 | `presentation/viewmodel/` | ViewModels con `@HiltViewModel`. Exponen `StateFlow<UiState>` y clasifican excepciones (`IOException` → red, `HttpException` 404 → NotFound, otros → servidor). Re-lanzan `CancellationException` para preservar structured concurrency. |
-| `presentation/ui/screens/` | Composables por entidad (`album/`, `artist/`, `collector/`). |
-| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `CollectorCard`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`. |
+| `presentation/ui/screens/` | Composables por entidad (`album/`, `artist/`). |
+| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`, `SearchBarStatic`. |
 | `presentation/ui/theme/` | Material 3: `Color.kt`, `Theme.kt`, `Type.kt`. |
 
 ---
@@ -96,7 +95,7 @@ Módulos de Hilt instalados en `SingletonComponent`.
 | Archivo | Contenido |
 |---|---|
 | `NetworkModule` | Provee `OkHttpClient` (con `HttpLoggingInterceptor` solo en debug), `Retrofit` y `VinilosApiService`. |
-| `DatabaseModule` | Provee `VinilosDatabase` (con `fallbackToDestructiveMigration` — la caché es descartable) y los tres DAOs. |
+| `DatabaseModule` | Provee `VinilosDatabase` (con `fallbackToDestructiveMigration` — la caché es descartable) y los DAOs (`AlbumDao`, `MusicianDao`). |
 | `RepositoryModule` | `@Binds` de las interfaces de dominio a sus implementaciones. |
 
 ---

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,6 +95,11 @@ dependencies {
     implementation(libs.retrofit.gson)
     implementation(libs.okhttp.logging)
 
+    // Room
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    ksp(libs.room.compiler)
+
     // Coil
     implementation(libs.coil.compose)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            buildConfigField("String", "BASE_URL", "\"http://54.82.57.177:3000/\"")
+            buildConfigField("String", "BASE_URL", "\"http://35.237.29.155:3000/\"")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            buildConfigField("String", "BASE_URL", "\"https://vinilos-d3465b582eda.herokuapp.com/\"")
+            buildConfigField("String", "BASE_URL", "\"http://54.82.57.177:3000/\"")
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "com.misw4203.vinilos.HiltTestRunner"
     }
 
     signingConfigs {
@@ -110,8 +110,11 @@ dependencies {
     testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.hilt.android.testing)
+    kspAndroidTest(libs.hilt.compiler)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/HiltTestRunner.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/HiltTestRunner.kt
@@ -1,0 +1,14 @@
+package com.misw4203.vinilos
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?,
+    ): Application = super.newApplication(cl, HiltTestApplication::class.java.name, context)
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeAlbumRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeAlbumRepository.kt
@@ -1,0 +1,31 @@
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.model.Performer
+import com.misw4203.vinilos.domain.model.Track
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import javax.inject.Inject
+
+class FakeAlbumRepository @Inject constructor() : AlbumRepository {
+
+    override suspend fun getAlbums(): List<Album> = listOf(
+        Album(1L, "Buscando América", "", "Rubén Blades", "1984", "Salsa"),
+        Album(2L, "A Night at the Opera", "", "Queen", "1975", "Rock"),
+    )
+
+    override suspend fun getAlbumById(id: Long): AlbumDetail = AlbumDetail(
+        id = id,
+        name = "Buscando América",
+        coverUrl = "",
+        artistName = "Rubén Blades",
+        releaseDate = "1984-01-01",
+        genre = "Salsa",
+        recordLabel = "Elektra",
+        description = "Álbum debut de Rubén Blades con Seis del Solar.",
+        tracks = listOf(Track(1L, "Decisiones", "5:12")),
+        performers = listOf(Performer(1L, "Rubén Blades", "")),
+        comments = listOf(Comment(1L, "Gran álbum", 5)),
+    )
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeMusicianRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeMusicianRepository.kt
@@ -1,0 +1,25 @@
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Musician
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import javax.inject.Inject
+
+class FakeMusicianRepository @Inject constructor() : MusicianRepository {
+
+    override suspend fun getMusicians(): List<MusicianSummary> = listOf(
+        MusicianSummary(100, "Rubén Blades", "", "1948-07-16T00:00:00.000Z"),
+        MusicianSummary(101, "Freddie Mercury", "", "1946-09-05T00:00:00.000Z"),
+    )
+
+    override suspend fun getMusicianDetail(id: Int): Musician = Musician(
+        id = id,
+        name = "Rubén Blades",
+        image = "",
+        description = "Cantante, compositor y político panameño.",
+        birthDate = "1948-07-16T00:00:00.000Z",
+        albums = listOf(Album(1L, "Buscando América", "", "Rubén Blades", "1984", "Salsa")),
+        prizes = emptyList(),
+    )
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
@@ -1,0 +1,25 @@
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [RepositoryModule::class],
+)
+abstract class FakeRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAlbumRepository(impl: FakeAlbumRepository): AlbumRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindMusicianRepository(impl: FakeMusicianRepository): MusicianRepository
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -1,7 +1,9 @@
 package com.misw4203.vinilos.e2e
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -59,10 +61,9 @@ class VinilosE2ETest {
     fun albumList_tapFirstCard_opensDetail_andBackReturns() {
         waitForTag("albums_list")
 
-        val firstTag = firstExistingTag("album_card_", 1L..50L)
-        composeRule.onNodeWithTag("albums_list")
-            .performScrollToNode(hasTestTag(firstTag))
-        composeRule.onNodeWithTag(firstTag).performClick()
+        val firstCard = tagStartsWith("album_card_")
+        composeRule.onNodeWithTag("albums_list").performScrollToNode(firstCard)
+        composeRule.onAllNodes(firstCard)[0].performClick()
 
         waitForTag("album_detail_root")
         composeRule.onNodeWithTag("album_detail_root").assertIsDisplayed()
@@ -90,8 +91,8 @@ class VinilosE2ETest {
         composeRule.onNodeWithTag("bottom_nav_artists").performClick()
 
         waitForTag("artists_list")
-        val firstTag = firstExistingTag("musician_card_", 1..200)
-        composeRule.onNodeWithTag(firstTag).performClick()
+        val firstCard = tagStartsWith("musician_card_")
+        composeRule.onAllNodes(firstCard)[0].performClick()
 
         waitForTag("artist_detail_root")
         composeRule.onNodeWithTag("artist_detail_root").assertIsDisplayed()
@@ -128,8 +129,9 @@ class VinilosE2ETest {
     fun systemBack_fromAlbumDetail_returnsToList() {
         waitForTag("albums_list")
 
-        val firstTag = firstExistingTag("album_card_", 1L..50L)
-        composeRule.onNodeWithTag(firstTag).performClick()
+        val firstCard = tagStartsWith("album_card_")
+        composeRule.onNodeWithTag("albums_list").performScrollToNode(firstCard)
+        composeRule.onAllNodes(firstCard)[0].performClick()
         waitForTag("album_detail_root")
 
         Espresso.pressBack()
@@ -144,8 +146,9 @@ class VinilosE2ETest {
     @Test
     fun albumDetail_ratingHasAccessibleContentDescription_ifCommentsPresent() {
         waitForTag("albums_list")
-        val firstTag = firstExistingTag("album_card_", 1L..50L)
-        composeRule.onNodeWithTag(firstTag).performClick()
+        val firstCard = tagStartsWith("album_card_")
+        composeRule.onNodeWithTag("albums_list").performScrollToNode(firstCard)
+        composeRule.onAllNodes(firstCard)[0].performClick()
         waitForTag("album_detail_root")
 
         // cd_rating en strings.xml tiene el texto "… de 5 estrellas". Si el álbum
@@ -173,13 +176,10 @@ class VinilosE2ETest {
         }
     }
 
-    private fun firstExistingTag(prefix: String, range: LongRange): String =
-        range.map { "$prefix$it" }.first { tag ->
-            composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
-        }
-
-    private fun firstExistingTag(prefix: String, range: IntRange): String =
-        range.map { "$prefix$it" }.first { tag ->
-            composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
+    /** Matcher que encuentra cualquier nodo cuyo testTag empiece con el prefijo dado. */
+    private fun tagStartsWith(prefix: String): SemanticsMatcher =
+        SemanticsMatcher("TestTag starts with '$prefix'") { node ->
+            val tag = node.config.getOrNull(SemanticsProperties.TestTag) ?: return@SemanticsMatcher false
+            tag.startsWith(prefix)
         }
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -1,0 +1,185 @@
+package com.misw4203.vinilos.e2e
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.espresso.Espresso
+import com.misw4203.vinilos.MainActivity
+import com.misw4203.vinilos.R
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Pruebas E2E (scope B): atacan MainActivity real con Hilt y el backend levantado
+ * en http://10.0.2.2:3000 (docker backvynils-web-1).
+ *
+ * Requisitos para ejecutar:
+ *   - Emulador Android corriendo.
+ *   - Backend docker-compose up en el host (puertos 3000 y 5432).
+ *   - testInstrumentationRunner = com.misw4203.vinilos.HiltTestRunner.
+ */
+@HiltAndroidTest
+class VinilosE2ETest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    private val timeoutMs = 10_000L
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    // -- Albums --------------------------------------------------------------
+
+    /** AL-01: la pantalla de álbumes carga y muestra la lista. */
+    @Test
+    fun albumList_rendersListFromBackend() {
+        waitForTag("albums_list")
+        composeRule.onNodeWithTag("albums_list").assertIsDisplayed()
+    }
+
+    /** AL-05 + AD-01 + AD-02: tap en primer álbum abre detalle y back regresa. */
+    @Test
+    fun albumList_tapFirstCard_opensDetail_andBackReturns() {
+        waitForTag("albums_list")
+
+        val firstTag = firstExistingTag("album_card_", 1L..50L)
+        composeRule.onNodeWithTag("albums_list")
+            .performScrollToNode(hasTestTag(firstTag))
+        composeRule.onNodeWithTag(firstTag).performClick()
+
+        waitForTag("album_detail_root")
+        composeRule.onNodeWithTag("album_detail_root").assertIsDisplayed()
+
+        composeRule.onNodeWithTag("album_detail_back").performClick()
+
+        waitForTag("albums_list")
+        composeRule.onNodeWithTag("albums_list").assertIsDisplayed()
+    }
+
+    // -- Artists -------------------------------------------------------------
+
+    /** ML-01: la pantalla de artistas carga al entrar desde bottom nav. */
+    @Test
+    fun artistList_rendersListFromBackend() {
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+
+        waitForTag("artists_list")
+        composeRule.onNodeWithTag("artists_list").assertIsDisplayed()
+    }
+
+    /** ML-04 + MD-01 + MD-04: tap en artista abre detalle y back regresa. */
+    @Test
+    fun artistList_tapFirstCard_opensDetail_andBackReturns() {
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+
+        waitForTag("artists_list")
+        val firstTag = firstExistingTag("musician_card_", 1..200)
+        composeRule.onNodeWithTag(firstTag).performClick()
+
+        waitForTag("artist_detail_root")
+        composeRule.onNodeWithTag("artist_detail_root").assertIsDisplayed()
+
+        composeRule.onNodeWithTag("artist_detail_back").performClick()
+
+        waitForTag("artists_list")
+        composeRule.onNodeWithTag("artists_list").assertIsDisplayed()
+    }
+
+    // -- Navigation ----------------------------------------------------------
+
+    /** NAV-01: cambiar entre Albums y Artists vía bottom nav cambia el título. */
+    @Test
+    fun bottomNav_switchesBetweenTabs() {
+        val ctx = composeRule.activity
+        val albumsTitle = ctx.getString(R.string.albums_title)
+        val artistsTitle = ctx.getString(R.string.artists_title)
+
+        waitForTag("albums_list")
+        composeRule.onNodeWithText(albumsTitle).assertIsDisplayed()
+
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+        waitForText(artistsTitle)
+        composeRule.onNodeWithText(artistsTitle).assertIsDisplayed()
+
+        composeRule.onNodeWithTag("bottom_nav_albums").performClick()
+        waitForTag("albums_list")
+        composeRule.onNodeWithText(albumsTitle).assertIsDisplayed()
+    }
+
+    /** NAV-03: back del sistema desde detalle de álbum regresa a lista. */
+    @Test
+    fun systemBack_fromAlbumDetail_returnsToList() {
+        waitForTag("albums_list")
+
+        val firstTag = firstExistingTag("album_card_", 1L..50L)
+        composeRule.onNodeWithTag(firstTag).performClick()
+        waitForTag("album_detail_root")
+
+        Espresso.pressBack()
+
+        waitForTag("albums_list")
+        composeRule.onNodeWithTag("albums_list").assertIsDisplayed()
+    }
+
+    // -- Accessibility -------------------------------------------------------
+
+    /** AD-05: si el álbum tiene comentarios, el rating expone contentDescription. */
+    @Test
+    fun albumDetail_ratingHasAccessibleContentDescription_ifCommentsPresent() {
+        waitForTag("albums_list")
+        val firstTag = firstExistingTag("album_card_", 1L..50L)
+        composeRule.onNodeWithTag(firstTag).performClick()
+        waitForTag("album_detail_root")
+
+        // cd_rating en strings.xml tiene el texto "… de 5 estrellas". Si el álbum
+        // no tiene comentarios este nodo no existirá y el test sale como no-op.
+        val ratingNodes = composeRule
+            .onAllNodesWithContentDescription(label = "de 5", substring = true)
+            .fetchSemanticsNodes()
+        if (ratingNodes.isEmpty()) return
+
+        composeRule.onNodeWithContentDescription(label = "de 5", substring = true)
+            .assertIsDisplayed()
+    }
+
+    // -- Helpers -------------------------------------------------------------
+
+    private fun waitForTag(tag: String) {
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForText(text: String) {
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun firstExistingTag(prefix: String, range: LongRange): String =
+        range.map { "$prefix$it" }.first { tag ->
+            composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
+        }
+
+    private fun firstExistingTag(prefix: String, range: IntRange): String =
+        range.map { "$prefix$it" }.first { tag ->
+            composeRule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
+        }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -158,8 +158,11 @@ class VinilosE2ETest {
             .fetchSemanticsNodes()
         if (ratingNodes.isEmpty()) return
 
-        composeRule.onNodeWithContentDescription(label = "de 5", substring = true)
-            .assertIsDisplayed()
+        // assertExists (no assertIsDisplayed): el nodo puede estar fuera del viewport;
+        // para accesibilidad basta con que exista en el semantic tree — TalkBack lo anuncia
+        // cuando el usuario hace scroll.
+        composeRule.onAllNodesWithContentDescription(label = "de 5", substring = true)[0]
+            .assertExists()
     }
 
     // -- Helpers -------------------------------------------------------------

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -23,13 +22,9 @@ import org.junit.Rule
 import org.junit.Test
 
 /**
- * Pruebas E2E (scope B): atacan MainActivity real con Hilt y el backend levantado
- * en http://10.0.2.2:3000 (docker backvynils-web-1).
- *
- * Requisitos para ejecutar:
- *   - Emulador Android corriendo.
- *   - Backend docker-compose up en el host (puertos 3000 y 5432).
- *   - testInstrumentationRunner = com.misw4203.vinilos.HiltTestRunner.
+ * Pruebas E2E: lanzan MainActivity real con Hilt usando FakeRepositoryModule,
+ * por lo que no requieren backend externo. Solo necesitan el emulador y
+ * testInstrumentationRunner = com.misw4203.vinilos.HiltTestRunner.
  */
 @HiltAndroidTest
 class VinilosE2ETest {
@@ -40,7 +35,7 @@ class VinilosE2ETest {
     @get:Rule(order = 1)
     val composeRule = createAndroidComposeRule<MainActivity>()
 
-    private val timeoutMs = 10_000L
+    private val timeoutMs = 3_000L
 
     @Before
     fun setUp() {
@@ -49,14 +44,16 @@ class VinilosE2ETest {
 
     // -- Albums --------------------------------------------------------------
 
-    /** AL-01: la pantalla de álbumes carga y muestra la lista. */
+    /** AL-01: la pantalla de álbumes carga y muestra los álbumes del catálogo. */
     @Test
-    fun albumList_rendersListFromBackend() {
+    fun albumList_rendersList() {
         waitForTag("albums_list")
         composeRule.onNodeWithTag("albums_list").assertIsDisplayed()
+        composeRule.onNodeWithText("Buscando América").assertIsDisplayed()
+        composeRule.onNodeWithText("A Night at the Opera").assertIsDisplayed()
     }
 
-    /** AL-05 + AD-01 + AD-02: tap en primer álbum abre detalle y back regresa. */
+    /** AL-05 + AD-01 + AD-02: tap en primer álbum abre detalle con contenido y back regresa. */
     @Test
     fun albumList_tapFirstCard_opensDetail_andBackReturns() {
         waitForTag("albums_list")
@@ -67,6 +64,7 @@ class VinilosE2ETest {
 
         waitForTag("album_detail_root")
         composeRule.onNodeWithTag("album_detail_root").assertIsDisplayed()
+        composeRule.onNodeWithText("Buscando América").assertIsDisplayed()
 
         composeRule.onNodeWithTag("album_detail_back").performClick()
 
@@ -76,16 +74,18 @@ class VinilosE2ETest {
 
     // -- Artists -------------------------------------------------------------
 
-    /** ML-01: la pantalla de artistas carga al entrar desde bottom nav. */
+    /** ML-01: la pantalla de artistas carga y muestra los músicos del catálogo. */
     @Test
-    fun artistList_rendersListFromBackend() {
+    fun artistList_rendersList() {
         composeRule.onNodeWithTag("bottom_nav_artists").performClick()
 
         waitForTag("artists_list")
         composeRule.onNodeWithTag("artists_list").assertIsDisplayed()
+        composeRule.onNodeWithText("Rubén Blades").assertIsDisplayed()
+        composeRule.onNodeWithText("Freddie Mercury").assertIsDisplayed()
     }
 
-    /** ML-04 + MD-01 + MD-04: tap en artista abre detalle y back regresa. */
+    /** ML-04 + MD-01 + MD-04: tap en artista abre detalle con contenido y back regresa. */
     @Test
     fun artistList_tapFirstCard_opensDetail_andBackReturns() {
         composeRule.onNodeWithTag("bottom_nav_artists").performClick()
@@ -96,6 +96,8 @@ class VinilosE2ETest {
 
         waitForTag("artist_detail_root")
         composeRule.onNodeWithTag("artist_detail_root").assertIsDisplayed()
+        composeRule.onNodeWithText("Rubén Blades").assertIsDisplayed()
+        composeRule.onNodeWithText("1948-07-16").assertIsDisplayed()
 
         composeRule.onNodeWithTag("artist_detail_back").performClick()
 
@@ -124,6 +126,18 @@ class VinilosE2ETest {
         composeRule.onNodeWithText(albumsTitle).assertIsDisplayed()
     }
 
+    /** NAV-02: el tab Collectors es alcanzable sin errores. */
+    @Test
+    fun collectorsTab_isReachableFromBottomNav() {
+        waitForTag("albums_list")
+        composeRule.onNodeWithTag("bottom_nav_collectors").performClick()
+        // Verificar que salimos de la lista de álbumes
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("albums_list").fetchSemanticsNodes().isEmpty()
+        }
+        composeRule.onNodeWithTag("bottom_nav_collectors").assertIsDisplayed()
+    }
+
     /** NAV-03: back del sistema desde detalle de álbum regresa a lista. */
     @Test
     fun systemBack_fromAlbumDetail_returnsToList() {
@@ -142,25 +156,17 @@ class VinilosE2ETest {
 
     // -- Accessibility -------------------------------------------------------
 
-    /** AD-05: si el álbum tiene comentarios, el rating expone contentDescription. */
+    /** AD-05: el rating del álbum expone contentDescription accesible (el fake siempre tiene comentarios). */
     @Test
-    fun albumDetail_ratingHasAccessibleContentDescription_ifCommentsPresent() {
+    fun albumDetail_ratingHasAccessibleContentDescription() {
         waitForTag("albums_list")
         val firstCard = tagStartsWith("album_card_")
         composeRule.onNodeWithTag("albums_list").performScrollToNode(firstCard)
         composeRule.onAllNodes(firstCard)[0].performClick()
         waitForTag("album_detail_root")
 
-        // cd_rating en strings.xml tiene el texto "… de 5 estrellas". Si el álbum
-        // no tiene comentarios este nodo no existirá y el test sale como no-op.
-        val ratingNodes = composeRule
-            .onAllNodesWithContentDescription(label = "de 5", substring = true)
-            .fetchSemanticsNodes()
-        if (ratingNodes.isEmpty()) return
-
         // assertExists (no assertIsDisplayed): el nodo puede estar fuera del viewport;
-        // para accesibilidad basta con que exista en el semantic tree — TalkBack lo anuncia
-        // cuando el usuario hace scroll.
+        // para accesibilidad basta con que exista en el semantic tree — TalkBack lo anuncia.
         composeRule.onAllNodesWithContentDescription(label = "de 5", substring = true)[0]
             .assertExists()
     }

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreenTest.kt
@@ -13,6 +13,7 @@ import com.misw4203.vinilos.domain.usecase.GetAlbumsUseCase
 import com.misw4203.vinilos.presentation.viewmodel.AlbumListViewModel
 import org.junit.Rule
 import org.junit.Test
+import java.io.IOException
 
 class AlbumListScreenTest {
 
@@ -59,5 +60,31 @@ class AlbumListScreenTest {
         }
         val ctx = composeTestRule.activity
         composeTestRule.onNodeWithText(ctx.getString(R.string.state_empty_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersNetworkErrorState() {
+        val viewModel = vm(Result.failure(IOException("sin red")))
+        composeTestRule.setContent {
+            MaterialTheme {
+                AlbumListScreen(onAlbumClick = {}, viewModel = viewModel)
+            }
+        }
+        val ctx = composeTestRule.activity
+        composeTestRule.onNodeWithText(ctx.getString(R.string.state_error_body_network))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersServerErrorState() {
+        val viewModel = vm(Result.failure(RuntimeException("error servidor")))
+        composeTestRule.setContent {
+            MaterialTheme {
+                AlbumListScreen(onAlbumClick = {}, viewModel = viewModel)
+            }
+        }
+        val ctx = composeTestRule.activity
+        composeTestRule.onNodeWithText(ctx.getString(R.string.state_error_body_server))
+            .assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreenTest.kt
@@ -13,6 +13,7 @@ import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
 import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
 import org.junit.Rule
 import org.junit.Test
+import java.io.IOException
 
 class MusicianListScreenTest {
 
@@ -84,5 +85,31 @@ class MusicianListScreenTest {
 
         val ctx = composeTestRule.activity
         composeTestRule.onNodeWithText(ctx.getString(R.string.search_placeholder_artists)).assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersNetworkErrorState() {
+        val viewModel = vm(Result.failure(IOException("sin red")))
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianListScreen(onMusicianClick = {}, viewModel = viewModel)
+            }
+        }
+        val ctx = composeTestRule.activity
+        composeTestRule.onNodeWithText(ctx.getString(R.string.state_error_body_network))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersServerErrorState() {
+        val viewModel = vm(Result.failure(RuntimeException("error servidor")))
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianListScreen(onMusicianClick = {}, viewModel = viewModel)
+            }
+        }
+        val ctx = composeTestRule.activity
+        composeTestRule.onNodeWithText(ctx.getString(R.string.state_error_body_server))
+            .assertIsDisplayed()
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         android:name=".VinilosApplication"
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt
@@ -1,0 +1,49 @@
+package com.misw4203.vinilos.data.local.converter
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.model.MusicianPrize
+import com.misw4203.vinilos.domain.model.Performer
+import com.misw4203.vinilos.domain.model.Track
+
+class Converters {
+    private val gson = Gson()
+
+    @TypeConverter
+    fun tracksToJson(value: List<Track>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToTracks(value: String): List<Track> =
+        gson.fromJson(value, object : TypeToken<List<Track>>() {}.type)
+
+    @TypeConverter
+    fun performersToJson(value: List<Performer>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToPerformers(value: String): List<Performer> =
+        gson.fromJson(value, object : TypeToken<List<Performer>>() {}.type)
+
+    @TypeConverter
+    fun commentsToJson(value: List<Comment>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToComments(value: String): List<Comment> =
+        gson.fromJson(value, object : TypeToken<List<Comment>>() {}.type)
+
+    @TypeConverter
+    fun albumsToJson(value: List<Album>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToAlbums(value: String): List<Album> =
+        gson.fromJson(value, object : TypeToken<List<Album>>() {}.type)
+
+    @TypeConverter
+    fun prizesToJson(value: List<MusicianPrize>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToPrizes(value: String): List<MusicianPrize> =
+        gson.fromJson(value, object : TypeToken<List<MusicianPrize>>() {}.type)
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/dao/AlbumDao.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/dao/AlbumDao.kt
@@ -1,0 +1,33 @@
+package com.misw4203.vinilos.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
+import com.misw4203.vinilos.data.local.entity.AlbumEntity
+
+@Dao
+interface AlbumDao {
+
+    @Query("SELECT * FROM albums ORDER BY name ASC")
+    suspend fun getAll(): List<AlbumEntity>
+
+    @Upsert
+    suspend fun upsertAll(albums: List<AlbumEntity>)
+
+    @Query("DELETE FROM albums")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun replaceAlbums(albums: List<AlbumEntity>) {
+        clear()
+        upsertAll(albums)
+    }
+
+    @Query("SELECT * FROM album_details WHERE id = :id")
+    suspend fun getDetailById(id: Long): AlbumDetailEntity?
+
+    @Upsert
+    suspend fun upsertDetail(detail: AlbumDetailEntity)
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/dao/MusicianDao.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/dao/MusicianDao.kt
@@ -1,0 +1,33 @@
+package com.misw4203.vinilos.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import com.misw4203.vinilos.data.local.entity.MusicianDetailEntity
+import com.misw4203.vinilos.data.local.entity.MusicianListEntity
+
+@Dao
+interface MusicianDao {
+
+    @Query("SELECT * FROM musicians ORDER BY name ASC")
+    suspend fun getAll(): List<MusicianListEntity>
+
+    @Upsert
+    suspend fun upsertAll(musicians: List<MusicianListEntity>)
+
+    @Query("DELETE FROM musicians")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun replaceMusicians(musicians: List<MusicianListEntity>) {
+        clear()
+        upsertAll(musicians)
+    }
+
+    @Query("SELECT * FROM musician_details WHERE id = :id")
+    suspend fun getDetailById(id: Int): MusicianDetailEntity?
+
+    @Upsert
+    suspend fun upsertDetail(detail: MusicianDetailEntity)
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
@@ -1,0 +1,28 @@
+package com.misw4203.vinilos.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.misw4203.vinilos.data.local.converter.Converters
+import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.dao.MusicianDao
+import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
+import com.misw4203.vinilos.data.local.entity.AlbumEntity
+import com.misw4203.vinilos.data.local.entity.MusicianDetailEntity
+import com.misw4203.vinilos.data.local.entity.MusicianListEntity
+
+@Database(
+    entities = [
+        AlbumEntity::class,
+        AlbumDetailEntity::class,
+        MusicianListEntity::class,
+        MusicianDetailEntity::class,
+    ],
+    version = 1,
+    exportSchema = false,
+)
+@TypeConverters(Converters::class)
+abstract class VinilosDatabase : RoomDatabase() {
+    abstract fun albumDao(): AlbumDao
+    abstract fun musicianDao(): MusicianDao
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumDetailEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumDetailEntity.kt
@@ -1,0 +1,53 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.model.Performer
+import com.misw4203.vinilos.domain.model.Track
+
+@Entity(tableName = "album_details")
+data class AlbumDetailEntity(
+    @PrimaryKey val id: Long,
+    val name: String,
+    val coverUrl: String,
+    val artistName: String,
+    val releaseDate: String,
+    val genre: String,
+    val recordLabel: String,
+    val description: String,
+    val tracks: List<Track>,
+    val performers: List<Performer>,
+    val comments: List<Comment>,
+) {
+    fun toDomain() = AlbumDetail(
+        id = id,
+        name = name,
+        coverUrl = coverUrl,
+        artistName = artistName,
+        releaseDate = releaseDate,
+        genre = genre,
+        recordLabel = recordLabel,
+        description = description,
+        tracks = tracks,
+        performers = performers,
+        comments = comments,
+    )
+
+    companion object {
+        fun fromDomain(detail: AlbumDetail) = AlbumDetailEntity(
+            id = detail.id,
+            name = detail.name,
+            coverUrl = detail.coverUrl,
+            artistName = detail.artistName,
+            releaseDate = detail.releaseDate,
+            genre = detail.genre,
+            recordLabel = detail.recordLabel,
+            description = detail.description,
+            tracks = detail.tracks,
+            performers = detail.performers,
+            comments = detail.comments,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumEntity.kt
@@ -1,0 +1,35 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.Album
+
+@Entity(tableName = "albums")
+data class AlbumEntity(
+    @PrimaryKey val id: Long,
+    val name: String,
+    val coverUrl: String,
+    val artistName: String,
+    val releaseYear: String,
+    val genre: String,
+) {
+    fun toDomain() = Album(
+        id = id,
+        name = name,
+        coverUrl = coverUrl,
+        artistName = artistName,
+        releaseYear = releaseYear,
+        genre = genre,
+    )
+
+    companion object {
+        fun fromDomain(album: Album) = AlbumEntity(
+            id = album.id,
+            name = album.name,
+            coverUrl = album.coverUrl,
+            artistName = album.artistName,
+            releaseYear = album.releaseYear,
+            genre = album.genre,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianDetailEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianDetailEntity.kt
@@ -1,0 +1,40 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Musician
+import com.misw4203.vinilos.domain.model.MusicianPrize
+
+@Entity(tableName = "musician_details")
+data class MusicianDetailEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val birthDate: String,
+    val albums: List<Album>,
+    val prizes: List<MusicianPrize>,
+) {
+    fun toDomain() = Musician(
+        id = id,
+        name = name,
+        image = image,
+        description = description,
+        birthDate = birthDate,
+        albums = albums,
+        prizes = prizes,
+    )
+
+    companion object {
+        fun fromDomain(musician: Musician) = MusicianDetailEntity(
+            id = musician.id,
+            name = musician.name,
+            image = musician.image,
+            description = musician.description,
+            birthDate = musician.birthDate,
+            albums = musician.albums,
+            prizes = musician.prizes,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianListEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianListEntity.kt
@@ -1,0 +1,29 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+@Entity(tableName = "musicians")
+data class MusicianListEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+    val birthDate: String,
+) {
+    fun toDomain() = MusicianSummary(
+        id = id,
+        name = name,
+        image = image,
+        birthDate = birthDate,
+    )
+
+    companion object {
+        fun fromDomain(summary: MusicianSummary) = MusicianListEntity(
+            id = summary.id,
+            name = summary.name,
+            image = summary.image,
+            birthDate = summary.birthDate,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
@@ -1,5 +1,8 @@
 package com.misw4203.vinilos.data.repository
 
+import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
+import com.misw4203.vinilos.data.local.entity.AlbumEntity
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
 import com.misw4203.vinilos.domain.model.Album
@@ -10,18 +13,33 @@ import com.misw4203.vinilos.domain.model.Track
 import com.misw4203.vinilos.domain.repository.AlbumRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import javax.inject.Inject
 
 class AlbumRepositoryImpl @Inject constructor(
     private val api: VinilosApiService,
+    private val dao: AlbumDao,
 ) : AlbumRepository {
 
     override suspend fun getAlbums(): List<Album> = withContext(Dispatchers.IO) {
-        api.getAlbums().map { it.toAlbum() }
+        try {
+            val albums = api.getAlbums().map { it.toAlbum() }
+            dao.replaceAlbums(albums.map { AlbumEntity.fromDomain(it) })
+            albums
+        } catch (e: IOException) {
+            val cached = dao.getAll()
+            if (cached.isNotEmpty()) cached.map { it.toDomain() } else throw e
+        }
     }
 
     override suspend fun getAlbumById(id: Long): AlbumDetail = withContext(Dispatchers.IO) {
-        api.getAlbum(id).toAlbumDetail()
+        try {
+            val detail = api.getAlbum(id).toAlbumDetail()
+            dao.upsertDetail(AlbumDetailEntity.fromDomain(detail))
+            detail
+        } catch (e: IOException) {
+            dao.getDetailById(id)?.toDomain() ?: throw e
+        }
     }
 
     private fun AlbumDto.toAlbum(): Album = Album(

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImpl.kt
@@ -1,5 +1,8 @@
 package com.misw4203.vinilos.data.repository
 
+import com.misw4203.vinilos.data.local.dao.MusicianDao
+import com.misw4203.vinilos.data.local.entity.MusicianDetailEntity
+import com.misw4203.vinilos.data.local.entity.MusicianListEntity
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
@@ -13,33 +16,48 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import javax.inject.Inject
 
 class MusicianRepositoryImpl @Inject constructor(
     private val api: VinilosApiService,
+    private val dao: MusicianDao,
 ) : MusicianRepository {
 
     override suspend fun getMusicians(): List<MusicianSummary> = withContext(Dispatchers.IO) {
-        api.getMusicians().map { it.toSummary() }
+        try {
+            val summaries = api.getMusicians().map { it.toSummary() }
+            dao.replaceMusicians(summaries.map { MusicianListEntity.fromDomain(it) })
+            summaries
+        } catch (e: IOException) {
+            val cached = dao.getAll()
+            if (cached.isNotEmpty()) cached.map { it.toDomain() } else throw e
+        }
     }
 
     override suspend fun getMusicianDetail(id: Int): Musician = withContext(Dispatchers.IO) {
-        val dto = api.getMusicianDetail(id)
-        val prizes = coroutineScope {
-            dto.performerPrizes.map { pp ->
-                async {
-                    val prizeDto = api.getPrizeDetail(pp.id)
-                    MusicianPrize(
-                        id = prizeDto.id,
-                        name = prizeDto.name,
-                        organization = prizeDto.organization,
-                        description = prizeDto.description,
-                        premiationDate = pp.premiationDate,
-                    )
-                }
-            }.awaitAll()
+        try {
+            val dto = api.getMusicianDetail(id)
+            val prizes = coroutineScope {
+                dto.performerPrizes.map { pp ->
+                    async {
+                        val prizeDto = api.getPrizeDetail(pp.id)
+                        MusicianPrize(
+                            id = prizeDto.id,
+                            name = prizeDto.name,
+                            organization = prizeDto.organization,
+                            description = prizeDto.description,
+                            premiationDate = pp.premiationDate,
+                        )
+                    }
+                }.awaitAll()
+            }
+            val musician = dto.toDomain(prizes)
+            dao.upsertDetail(MusicianDetailEntity.fromDomain(musician))
+            musician
+        } catch (e: IOException) {
+            dao.getDetailById(id)?.toDomain() ?: throw e
         }
-        dto.toDomain(prizes)
     }
 
     private fun MusicianDetailDto.toSummary() = MusicianSummary(

--- a/app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt
+++ b/app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt
@@ -1,0 +1,31 @@
+package com.misw4203.vinilos.di
+
+import android.content.Context
+import androidx.room.Room
+import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.dao.MusicianDao
+import com.misw4203.vinilos.data.local.database.VinilosDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): VinilosDatabase =
+        Room.databaseBuilder(context, VinilosDatabase::class.java, "vinilos.db")
+            .fallbackToDestructiveMigration()
+            .build()
+
+    @Provides
+    fun provideAlbumDao(db: VinilosDatabase): AlbumDao = db.albumDao()
+
+    @Provides
+    fun provideMusicianDao(db: VinilosDatabase): MusicianDao = db.musicianDao()
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
 import androidx.compose.material.icons.outlined.Album
@@ -39,8 +42,9 @@ fun VinilosBottomNav(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(80.dp)
             .background(MaterialTheme.colorScheme.surface)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .height(80.dp)
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceAround,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -54,18 +55,21 @@ fun VinilosBottomNav(
             icon = if (selected == VinilosDestination.Albums) Icons.Filled.Album else Icons.Outlined.Album,
             active = selected == VinilosDestination.Albums,
             onClick = { onSelect(VinilosDestination.Albums) },
+            modifier = Modifier.testTag("bottom_nav_albums"),
         )
         NavTab(
             label = stringResource(R.string.nav_artists),
             icon = Icons.Outlined.PersonSearch,
             active = selected == VinilosDestination.Artists,
             onClick = { onSelect(VinilosDestination.Artists) },
+            modifier = Modifier.testTag("bottom_nav_artists"),
         )
         NavTab(
             label = stringResource(R.string.nav_collectors),
             icon = Icons.Outlined.Group,
             active = selected == VinilosDestination.Collectors,
             onClick = { onSelect(VinilosDestination.Collectors) },
+            modifier = Modifier.testTag("bottom_nav_collectors"),
         )
     }
 }
@@ -76,11 +80,12 @@ private fun NavTab(
     icon: ImageVector,
     active: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val tint = if (active) MaterialTheme.colorScheme.onSurface
     else MaterialTheme.colorScheme.outlineVariant
     Column(
-        modifier = Modifier
+        modifier = modifier
             .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -81,7 +82,7 @@ fun AlbumDetailScreen(
 
 @Composable
 private fun AlbumDetailContent(album: AlbumDetail, onBack: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().testTag("album_detail_root")) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -186,7 +187,8 @@ private fun AlbumDetailContent(album: AlbumDetail, onBack: () -> Unit) {
                 .padding(top = 8.dp, start = 8.dp)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.75f))
-                .size(40.dp),
+                .size(40.dp)
+                .testTag("album_detail_back"),
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -46,12 +47,17 @@ fun AlbumListScreen(
                 EmptyState()
             }
             is AlbumListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("albums_list"),
                 contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
             ) {
                 item { HeaderSection() }
                 items(state.albums, key = { it.id }) { album ->
-                    AlbumCard(album = album, onClick = { onAlbumClick(album.id) })
+                    AlbumCard(
+                        album = album,
+                        onClick = { onAlbumClick(album.id) },
+                        modifier = Modifier.testTag("album_card_${album.id}"),
+                    )
                 }
                 item { Spacer(Modifier.size(24.dp)) }
             }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -84,7 +85,7 @@ fun MusicianDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("artist_detail_back")) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.action_back),
@@ -137,7 +138,8 @@ private fun MusicianBody(musician: Musician) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .testTag("artist_detail_root"),
     ) {
         ArtistHeader(musician)
         Spacer(Modifier.height(24.dp))
@@ -316,7 +318,8 @@ private fun PrizeItem(prize: MusicianPrize, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onClick() },
+            .clickable { onClick() }
+            .testTag("prize_${prize.id}"),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,6 +49,7 @@ fun MusicianListScreen(
                 EmptyState()
             }
             is MusicianListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("artists_list"),
                 state = listState,
                 contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(24.dp),
@@ -57,6 +59,7 @@ fun MusicianListScreen(
                     MusicianCard(
                         musician = musician,
                         onClick = { onMusicianClick(musician.id) },
+                        modifier = Modifier.testTag("musician_card_${musician.id}"),
                     )
                 }
                 item { Spacer(Modifier.size(24.dp)) }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -4,6 +4,6 @@
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">127.0.0.1</domain>
-        <domain includeSubdomains="true">54.82.57.177</domain>
+        <domain includeSubdomains="true">35.237.29.155</domain>
     </domain-config>
 </network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -4,5 +4,6 @@
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">54.82.57.177</domain>
     </domain-config>
 </network-security-config>

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.misw4203.vinilos.data.repository
 
+import com.misw4203.vinilos.data.local.dao.AlbumDao
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
 import com.misw4203.vinilos.data.remote.dto.CommentDto
@@ -20,12 +21,14 @@ import java.io.IOException
 class AlbumRepositoryImplTest {
 
     private lateinit var api: VinilosApiService
+    private lateinit var dao: AlbumDao
     private lateinit var repository: AlbumRepositoryImpl
 
     @Before
     fun setUp() {
         api = mockk()
-        repository = AlbumRepositoryImpl(api)
+        dao = mockk(relaxed = true)
+        repository = AlbumRepositoryImpl(api, dao)
     }
 
     @Test
@@ -82,8 +85,9 @@ class AlbumRepositoryImplTest {
     }
 
     @Test(expected = IOException::class)
-    fun `getAlbumById propagates IOException`() = runTest {
+    fun `getAlbumById propagates IOException when cache is empty`() = runTest {
         coEvery { api.getAlbum(7L) } throws IOException("offline")
+        coEvery { dao.getDetailById(7L) } returns null
         repository.getAlbumById(7L)
     }
 

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.misw4203.vinilos.data.repository
 
+import com.misw4203.vinilos.data.local.dao.MusicianDao
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
 import com.misw4203.vinilos.data.remote.dto.PerformerPrizeDto
@@ -19,12 +20,14 @@ import java.io.IOException
 class MusicianRepositoryImplTest {
 
     private lateinit var api: VinilosApiService
+    private lateinit var dao: MusicianDao
     private lateinit var repository: MusicianRepositoryImpl
 
     @Before
     fun setUp() {
         api = mockk()
-        repository = MusicianRepositoryImpl(api)
+        dao = mockk(relaxed = true)
+        repository = MusicianRepositoryImpl(api, dao)
     }
 
     @Test
@@ -85,8 +88,9 @@ class MusicianRepositoryImplTest {
     }
 
     @Test(expected = IOException::class)
-    fun `getMusicianDetail propagates IOException`() = runTest {
+    fun `getMusicianDetail propagates IOException when cache is empty`() = runTest {
         coEvery { api.getMusicianDetail(2) } throws IOException("offline")
+        coEvery { dao.getDetailById(2) } returns null
         repository.getMusicianDetail(2)
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,8 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.6.2" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Resumen

  Pruebas E2E con Compose Test + Hilt apuntando al backend docker local. Además recoge fixes pendientes de la rama de feedback (bottom nav inset y
  reconstrucción de Room) que no se han mergeado a `develop`.

  ## Cambios

  ### Pruebas E2E (foco del PR)
  - Nueva suite `app/src/androidTest/.../e2e/VinilosE2ETest.kt` con 7 casos que cubren AL-01, AL-05, AD-01, AD-02, AD-05, ML-01, ML-04, MD-01, MD-04, NAV-01
   y NAV-03.
  - `HiltTestRunner` configurado como `testInstrumentationRunner` para arrancar `MainActivity` con Hilt real (scope B).
  - `testTag`s agregados en composables clave: `albums_list`, `artists_list`, `album_card_{id}`, `musician_card_{id}`, `bottom_nav_*`, `*_detail_root`,
  `*_detail_back`, `prize_{id}`.
  - `SemanticsMatcher` custom (`tagStartsWith`) para no depender de los IDs sembrados por el backend.
  - Documento dedicado `E2E_TESTS.md` con escenarios, casos detallados, matchers, lecciones aprendidas y siguientes pasos.

  ### Fixes arrastrados de feature/feadback
  - `fix(navigation)`: `windowInsetsPadding(WindowInsets.navigationBars)` en `VinilosBottomNav` para evitar solape con la barra de navegación virtual.
  - `feat(data)`: restauración completa de la capa Room (Converters, entities, DAOs, `VinilosDatabase`, `DatabaseModule`) y estrategia network-first con
  fallback a caché en `AlbumRepositoryImpl` y `MusicianRepositoryImpl`.
  - `docs(readme)`: README ajustado al estado actual del proyecto (sin el módulo Collector).

  ## Test plan

  - [x] `./gradlew test` → 45 unit tests verdes.
  - [x] `./gradlew assembleDebugAndroidTest` compila la suite instrumentada.
  - [x] `./gradlew connectedAndroidTest` con backend docker arriba y emulador **Pixel 8 API 34** → 24/24 tests verdes.
  - [x] APK debug instalado manualmente: bottom nav respeta el inset de la barra de navegación virtual.

  ## Notas

  - ⚠️ **Emulador API 35+ rompe Espresso 3.6.1** con `NoSuchMethodException: InputManager.getInstance` (`androidx.test` aún no soporta API 35 en stable).
  Usar API 33 o 34 hasta que salga el fix.
  - Los E2E asumen el backend en `http://10.0.2.2:3000` (docker `backvynils-web-1`). Sin docker corriendo los tests fallan en `waitForTag("albums_list")`.
  - Escenarios de Empty / Error / NotFound quedan cubiertos por unit tests de VM porque no se pueden forzar contra un backend real sin tumbarlo. La
  extensión vía `MockWebServer` queda como siguiente paso documentado en `E2E_TESTS.md`.

  ---
  Si prefieres que el PR sea solo del trabajo E2E (más limpio), conviene mergear primero feature/feadback a develop, hacer rebase de esta rama y reabrir el
  PR — quedaría con los 4 commits de E2E (4e3f5c9, 3b2cb03, 638ccea, 57f73ae) únicamente. ¿Quieres que vayamos por esa vía o el PR ancho como está?