### PR TITLE
Feature/hu09 comentar album

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ MEJORAS.md
 .claude/*
 skills-lock.json
 SPECS_DESARROLLO_4_DEVS.md
+SPECS_DESARROLLO_4_DEVS_MOVILES_SPRINT_2.md
 
 # Stitch files
 stitch_vinilos_app_screen_design_HU01/*

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeAlbumRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeAlbumRepository.kt
@@ -28,4 +28,11 @@ class FakeAlbumRepository @Inject constructor() : AlbumRepository {
         performers = listOf(Performer(1L, "Rubén Blades", "")),
         comments = listOf(Comment(1L, "Gran álbum", 5)),
     )
+
+    override suspend fun addComment(
+        albumId: Long,
+        description: String,
+        rating: Int,
+        collectorId: Int,
+    ): Comment = Comment(id = 99L, description = description, rating = rating)
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.Album
 import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
 import com.misw4203.vinilos.domain.repository.AlbumRepository
 import com.misw4203.vinilos.domain.usecase.GetAlbumsUseCase
 import com.misw4203.vinilos.presentation.viewmodel.AlbumListViewModel
@@ -25,6 +26,12 @@ class AlbumListScreenTest {
     ) : AlbumRepository {
         override suspend fun getAlbums(): List<Album> = result.getOrThrow()
         override suspend fun getAlbumById(id: Long): AlbumDetail = error("unused")
+        override suspend fun addComment(
+            albumId: Long,
+            description: String,
+            rating: Int,
+            collectorId: Int,
+        ): Comment = error("unused")
     }
 
     private fun vm(result: Result<List<Album>>) =

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
@@ -3,9 +3,13 @@ package com.misw4203.vinilos.data.remote.api
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
 import com.misw4203.vinilos.data.remote.dto.CollectorDetailDto
 import com.misw4203.vinilos.data.remote.dto.CollectorDto
+import com.misw4203.vinilos.data.remote.dto.CommentDto
+import com.misw4203.vinilos.data.remote.dto.CreateCommentRequest
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
 import com.misw4203.vinilos.data.remote.dto.PrizeDetailDto
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface VinilosApiService {
@@ -30,4 +34,10 @@ interface VinilosApiService {
 
     @GET("collectors/{id}")
     suspend fun getCollectorDetail(@Path("id") id: Int): CollectorDetailDto
+
+    @POST("albums/{id}/comments")
+    suspend fun addComment(
+        @Path("id") albumId: Long,
+        @Body request: CreateCommentRequest,
+    ): CommentDto
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/AlbumDto.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/AlbumDto.kt
@@ -34,4 +34,5 @@ data class CommentDto(
     @SerializedName("id") val id: Long,
     @SerializedName("description") val description: String?,
     @SerializedName("rating") val rating: Int?,
+    @SerializedName("collector") val collector: CollectorDto? = null,
 )

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/CreateCommentRequest.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/CreateCommentRequest.kt
@@ -1,0 +1,13 @@
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class CreateCommentRequest(
+    @SerializedName("description") val description: String,
+    @SerializedName("rating") val rating: Int,
+    @SerializedName("collector") val collector: CollectorRef,
+)
+
+data class CollectorRef(
+    @SerializedName("id") val id: Int,
+)

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
 import com.misw4203.vinilos.data.local.entity.AlbumEntity
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.CollectorRef
+import com.misw4203.vinilos.data.remote.dto.CreateCommentRequest
 import com.misw4203.vinilos.domain.model.Album
 import com.misw4203.vinilos.domain.model.AlbumDetail
 import com.misw4203.vinilos.domain.model.Comment
@@ -40,6 +42,27 @@ class AlbumRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             dao.getDetailById(id)?.toDomain() ?: throw e
         }
+    }
+
+    override suspend fun addComment(
+        albumId: Long,
+        description: String,
+        rating: Int,
+        collectorId: Int,
+    ): Comment = withContext(Dispatchers.IO) {
+        val response = api.addComment(
+            albumId = albumId,
+            request = CreateCommentRequest(
+                description = description,
+                rating = rating,
+                collector = CollectorRef(id = collectorId),
+            ),
+        )
+        Comment(
+            id = response.id,
+            description = response.description.orEmpty(),
+            rating = response.rating ?: rating,
+        )
     }
 
     private fun AlbumDto.toAlbum(): Album = Album(

--- a/app/src/main/java/com/misw4203/vinilos/domain/repository/AlbumRepository.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/repository/AlbumRepository.kt
@@ -2,8 +2,10 @@ package com.misw4203.vinilos.domain.repository
 
 import com.misw4203.vinilos.domain.model.Album
 import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
 
 interface AlbumRepository {
     suspend fun getAlbums(): List<Album>
     suspend fun getAlbumById(id: Long): AlbumDetail
+    suspend fun addComment(albumId: Long, description: String, rating: Int, collectorId: Int): Comment
 }

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddCommentUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddCommentUseCase.kt
@@ -1,0 +1,16 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import javax.inject.Inject
+
+class AddCommentUseCase @Inject constructor(
+    private val repository: AlbumRepository,
+) {
+    suspend operator fun invoke(
+        albumId: Long,
+        description: String,
+        rating: Int,
+        collectorId: Int,
+    ): Comment = repository.addComment(albumId, description, rating, collectorId)
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
@@ -11,6 +11,21 @@ object Destinations {
     const val CollectorDetail = "collector/{collectorId}"
     const val CollectorDetailArg = "collectorId"
 
+    const val AddComment = "album/{albumId}/comment/add/{collectorId}"
+    const val AddCommentAlbumArg = "albumId"
+    const val AddCommentCollectorArg = "collectorId"
+
+    /**
+     * The current build does not have a logged-in collector concept; HU09 spec
+     * requires the `collector` field in the POST body. We use this default id
+     * so the screen has a valid reference. Replace once auth is added.
+     */
+    const val DefaultCollectorId = 100
+
+    const val RefreshAlbumDetailKey = "refresh_album_detail"
+
     fun albumDetail(albumId: Long) = "album_detail/$albumId"
     fun collectorDetail(collectorId: Int) = "collector/$collectorId"
+    fun addComment(albumId: Long, collectorId: Int = DefaultCollectorId) =
+        "album/$albumId/comment/add/$collectorId"
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -15,6 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.misw4203.vinilos.presentation.ui.components.VinilosBottomNav
 import com.misw4203.vinilos.presentation.ui.components.VinilosDestination
+import com.misw4203.vinilos.presentation.ui.screens.album.AddCommentScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumListScreen
 import com.misw4203.vinilos.presentation.ui.screens.artist.MusicianDetailScreen
@@ -70,9 +72,36 @@ fun VinilosNavHost() {
                     arguments = listOf(navArgument(Destinations.AlbumDetailArg) { type = NavType.LongType }),
                 ) { entry ->
                     val albumId = entry.arguments?.getLong(Destinations.AlbumDetailArg) ?: 0L
+                    val refreshFlag by entry.savedStateHandle
+                        .getStateFlow(Destinations.RefreshAlbumDetailKey, false)
+                        .collectAsStateWithLifecycle()
                     AlbumDetailScreen(
                         albumId = albumId,
                         onBack = { navController.popBackStack() },
+                        onAddComment = {
+                            navController.navigate(Destinations.addComment(albumId))
+                        },
+                        refreshKey = refreshFlag,
+                        onRefreshHandled = {
+                            entry.savedStateHandle[Destinations.RefreshAlbumDetailKey] = false
+                        },
+                    )
+                }
+                composable(
+                    route = Destinations.AddComment,
+                    arguments = listOf(
+                        navArgument(Destinations.AddCommentAlbumArg) { type = NavType.LongType },
+                        navArgument(Destinations.AddCommentCollectorArg) { type = NavType.IntType },
+                    ),
+                ) {
+                    AddCommentScreen(
+                        onBack = { navController.popBackStack() },
+                        onSuccess = {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(Destinations.RefreshAlbumDetailKey, true)
+                            navController.popBackStack()
+                        },
                     )
                 }
                 composable(Destinations.ArtistList) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/ListCounter.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/ListCounter.kt
@@ -1,0 +1,29 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ListCounter(
+    text: String,
+    modifier: Modifier = Modifier,
+    testTag: String? = null,
+) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.outline,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 4.dp)
+            .let { if (testTag != null) it.testTag(testTag) else it },
+    )
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/RatingBar.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/RatingBar.kt
@@ -1,0 +1,50 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.misw4203.vinilos.R
+
+@Composable
+fun RatingBar(
+    rating: Int,
+    onRatingChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    starSize: Dp = 36.dp,
+    interactive: Boolean = true,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        (1..5).forEach { star ->
+            val isFilled = star <= rating
+            val cd = stringResource(R.string.cd_rating, star)
+            val starModifier = Modifier
+                .size(starSize)
+                .testTag("rating_star_$star")
+                .let {
+                    if (interactive) it.clickable { onRatingChange(star) } else it
+                }
+            Icon(
+                imageVector = if (isFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                contentDescription = cd,
+                tint = if (isFilled) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.outlineVariant,
+                modifier = starModifier,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
@@ -1,0 +1,285 @@
+package com.misw4203.vinilos.presentation.ui.screens.album
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.RatingBar
+import com.misw4203.vinilos.presentation.viewmodel.AddCommentFormState
+import com.misw4203.vinilos.presentation.viewmodel.AddCommentUiState
+import com.misw4203.vinilos.presentation.viewmodel.AddCommentViewModel
+import com.misw4203.vinilos.presentation.viewmodel.FormError
+
+private const val MaxDescriptionChars = 500
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddCommentScreen(
+    onBack: () -> Unit,
+    onSuccess: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddCommentViewModel = hiltViewModel(),
+) {
+    val form by viewModel.form.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val networkErrorMessage = stringResource(R.string.add_comment_error_network)
+    val serverErrorMessage = stringResource(R.string.add_comment_error_server)
+    val successMessage = stringResource(R.string.add_comment_success)
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is AddCommentUiState.Success -> {
+                snackbarHostState.showSnackbar(successMessage)
+                onSuccess()
+            }
+            is AddCommentUiState.Error -> {
+                val message = if (state.isNetworkError) networkErrorMessage else serverErrorMessage
+                snackbarHostState.showSnackbar(message)
+                viewModel.resetError()
+            }
+            else -> Unit
+        }
+    }
+
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag("add_comment_screen"),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.add_comment_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .clip(CircleShape)
+                            .testTag("add_comment_back"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        AddCommentContent(
+            form = form,
+            uiState = uiState,
+            onDescriptionChange = viewModel::onDescriptionChange,
+            onRatingChange = viewModel::onRatingChange,
+            onSubmit = viewModel::submit,
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun AddCommentContent(
+    form: AddCommentFormState,
+    uiState: AddCommentUiState,
+    onDescriptionChange: (String) -> Unit,
+    onRatingChange: (Int) -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isLoading = uiState is AddCommentUiState.Loading
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 24.dp),
+    ) {
+        SectionHeading(text = stringResource(R.string.add_comment_section))
+        Spacer(Modifier.height(20.dp))
+
+        FieldLabel(text = stringResource(R.string.add_comment_label_rating))
+        Spacer(Modifier.height(10.dp))
+        RatingBar(
+            rating = form.rating,
+            onRatingChange = onRatingChange,
+        )
+        if (form.ratingError == FormError.InvalidRating) {
+            Spacer(Modifier.height(6.dp))
+            ErrorText(stringResource(R.string.add_comment_error_rating))
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        FieldLabel(text = stringResource(R.string.add_comment_label_description))
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = form.description,
+            onValueChange = { value ->
+                if (value.length <= MaxDescriptionChars) onDescriptionChange(value)
+            },
+            placeholder = {
+                Text(
+                    text = stringResource(R.string.add_comment_placeholder),
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            },
+            isError = form.descriptionError == FormError.EmptyDescription,
+            supportingText = {
+                val errorText = if (form.descriptionError == FormError.EmptyDescription) {
+                    stringResource(R.string.add_comment_error_description)
+                } else null
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = errorText.orEmpty(),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Text(
+                        text = stringResource(
+                            R.string.add_comment_max_chars,
+                            MaxDescriptionChars,
+                        ),
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            },
+            shape = RoundedCornerShape(12.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 140.dp)
+                .testTag("add_comment_description"),
+        )
+
+        Spacer(Modifier.height(28.dp))
+
+        Button(
+            onClick = onSubmit,
+            enabled = !isLoading,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+                .testTag("add_comment_submit"),
+        ) {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Text(
+                    text = stringResource(R.string.add_comment_submit).uppercase(),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun SectionHeading(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = text.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun FieldLabel(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun ErrorText(message: String) {
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+    )
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
@@ -23,12 +23,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,14 +66,28 @@ fun AlbumDetailScreen(
     albumId: Long,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    onAddComment: () -> Unit = {},
+    refreshKey: Boolean = false,
+    onRefreshHandled: () -> Unit = {},
     viewModel: AlbumDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    LaunchedEffect(refreshKey) {
+        if (refreshKey) {
+            viewModel.retry()
+            onRefreshHandled()
+        }
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
         when (val state = uiState) {
             is AlbumDetailUiState.Loading -> LoadingState()
-            is AlbumDetailUiState.Success -> AlbumDetailContent(album = state.album, onBack = onBack)
+            is AlbumDetailUiState.Success -> AlbumDetailContent(
+                album = state.album,
+                onBack = onBack,
+                onAddComment = onAddComment,
+            )
             is AlbumDetailUiState.NotFound -> NotFoundState(onBack = onBack)
             is AlbumDetailUiState.Error -> ErrorState(
                 onRetry = viewModel::retry,
@@ -81,7 +98,11 @@ fun AlbumDetailScreen(
 }
 
 @Composable
-private fun AlbumDetailContent(album: AlbumDetail, onBack: () -> Unit) {
+private fun AlbumDetailContent(
+    album: AlbumDetail,
+    onBack: () -> Unit,
+    onAddComment: () -> Unit,
+) {
     Box(modifier = Modifier.fillMaxSize().testTag("album_detail_root")) {
         Column(
             modifier = Modifier
@@ -135,6 +156,27 @@ private fun AlbumDetailContent(album: AlbumDetail, onBack: () -> Unit) {
                             text = album.description,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    // Action: comment
+                    Spacer(Modifier.height(20.dp))
+                    Button(
+                        onClick = onAddComment,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .testTag("album_detail_add_comment"),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.add_comment_action_cta).uppercase(),
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
                         )
                     }
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
@@ -17,9 +17,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
+import androidx.compose.ui.res.pluralStringResource
 import com.misw4203.vinilos.presentation.ui.components.AlbumCard
 import com.misw4203.vinilos.presentation.ui.components.EmptyState
 import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
 import com.misw4203.vinilos.presentation.ui.components.LoadingState
 import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
 import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
@@ -52,6 +54,16 @@ fun AlbumListScreen(
                 verticalArrangement = Arrangement.spacedBy(24.dp),
             ) {
                 item { HeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.albums_record_count,
+                            state.albums.size,
+                            state.albums.size,
+                        ),
+                        testTag = "albums_record_count",
+                    )
+                }
                 items(state.albums, key = { it.id }) { album ->
                     AlbumCard(
                         album = album,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
+import androidx.compose.ui.res.pluralStringResource
 import com.misw4203.vinilos.presentation.ui.components.EmptyState
 import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
 import com.misw4203.vinilos.presentation.ui.components.LoadingState
 import com.misw4203.vinilos.presentation.ui.components.MusicianCard
 import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
@@ -55,6 +57,16 @@ fun MusicianListScreen(
                 verticalArrangement = Arrangement.spacedBy(24.dp),
             ) {
                 item { HeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.artists_record_count,
+                            state.musicians.size,
+                            state.musicians.size,
+                        ),
+                        testTag = "artists_record_count",
+                    )
+                }
                 items(state.musicians, key = { it.id }) { musician ->
                     MusicianCard(
                         musician = musician,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorListScreen.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
+import androidx.compose.ui.res.pluralStringResource
 import com.misw4203.vinilos.presentation.ui.components.CollectorCard
 import com.misw4203.vinilos.presentation.ui.components.EmptyState
 import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
 import com.misw4203.vinilos.presentation.ui.components.LoadingState
 import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
 import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
@@ -55,6 +57,16 @@ fun CollectorListScreen(
                 verticalArrangement = Arrangement.spacedBy(24.dp),
             ) {
                 item { HeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.collectors_record_count,
+                            state.collectors.size,
+                            state.collectors.size,
+                        ),
+                        testTag = "collectors_record_count",
+                    )
+                }
                 items(state.collectors, key = { it.id }) { collector ->
                     CollectorCard(
                         collector = collector,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentUiState.kt
@@ -1,0 +1,22 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Comment
+
+sealed interface AddCommentUiState {
+    data object Idle : AddCommentUiState
+    data object Loading : AddCommentUiState
+    data class Success(val comment: Comment) : AddCommentUiState
+    data class Error(val isNetworkError: Boolean) : AddCommentUiState
+}
+
+data class AddCommentFormState(
+    val description: String = "",
+    val rating: Int = 0,
+    val descriptionError: FormError? = null,
+    val ratingError: FormError? = null,
+)
+
+enum class FormError {
+    EmptyDescription,
+    InvalidRating,
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModel.kt
@@ -1,0 +1,78 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.AddCommentUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class AddCommentViewModel @Inject constructor(
+    private val addComment: AddCommentUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val albumId: Long = checkNotNull(savedStateHandle[Destinations.AddCommentAlbumArg])
+    private val collectorId: Int = checkNotNull(savedStateHandle[Destinations.AddCommentCollectorArg])
+
+    private val _form = MutableStateFlow(AddCommentFormState())
+    val form: StateFlow<AddCommentFormState> = _form.asStateFlow()
+
+    private val _uiState = MutableStateFlow<AddCommentUiState>(AddCommentUiState.Idle)
+    val uiState: StateFlow<AddCommentUiState> = _uiState.asStateFlow()
+
+    fun onDescriptionChange(value: String) {
+        _form.update { it.copy(description = value, descriptionError = null) }
+    }
+
+    fun onRatingChange(value: Int) {
+        _form.update { it.copy(rating = value.coerceIn(0, 5), ratingError = null) }
+    }
+
+    fun submit() {
+        val current = _form.value
+        val descriptionError = if (current.description.isBlank()) FormError.EmptyDescription else null
+        val ratingError = if (current.rating < 1) FormError.InvalidRating else null
+
+        if (descriptionError != null || ratingError != null) {
+            _form.update {
+                it.copy(descriptionError = descriptionError, ratingError = ratingError)
+            }
+            return
+        }
+
+        _uiState.value = AddCommentUiState.Loading
+        viewModelScope.launch {
+            _uiState.value = try {
+                val comment = addComment(
+                    albumId = albumId,
+                    description = current.description.trim(),
+                    rating = current.rating,
+                    collectorId = collectorId,
+                )
+                AddCommentUiState.Success(comment)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                AddCommentUiState.Error(isNetworkError = true)
+            } catch (e: Exception) {
+                AddCommentUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+
+    fun resetError() {
+        if (_uiState.value is AddCommentUiState.Error) {
+            _uiState.value = AddCommentUiState.Idle
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,20 @@
     <string name="cd_collector_avatar">Avatar del coleccionista</string>
     <string name="cd_open_collector">Abrir coleccionista</string>
 
+    <!-- List counters -->
+    <plurals name="albums_record_count">
+        <item quantity="one">%d álbum · orden alfa</item>
+        <item quantity="other">%d álbumes · orden alfa</item>
+    </plurals>
+    <plurals name="artists_record_count">
+        <item quantity="one">%d artista · orden alfa</item>
+        <item quantity="other">%d artistas · orden alfa</item>
+    </plurals>
+    <plurals name="collectors_record_count">
+        <item quantity="one">%d coleccionista · orden alfa</item>
+        <item quantity="other">%d coleccionistas · orden alfa</item>
+    </plurals>
+
     <!-- HU09 - Comentar álbum -->
     <string name="add_comment_title">Comentar álbum</string>
     <string name="add_comment_section">Nuevo comentario</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,19 @@
     <string name="cd_open_artist">Abrir artista</string>
     <string name="cd_collector_avatar">Avatar del coleccionista</string>
     <string name="cd_open_collector">Abrir coleccionista</string>
+
+    <!-- HU09 - Comentar álbum -->
+    <string name="add_comment_title">Comentar álbum</string>
+    <string name="add_comment_section">Nuevo comentario</string>
+    <string name="add_comment_label_rating">Calificación</string>
+    <string name="add_comment_label_description">Comentario</string>
+    <string name="add_comment_placeholder">Escribe tu comentario aquí…</string>
+    <string name="add_comment_max_chars">Máximo %1$d caracteres</string>
+    <string name="add_comment_submit">Publicar comentario</string>
+    <string name="add_comment_action_cta">+ Comentar</string>
+    <string name="add_comment_error_description">El comentario no puede estar vacío</string>
+    <string name="add_comment_error_rating">Selecciona una calificación de 1 a 5</string>
+    <string name="add_comment_error_network">Sin conexión. Intenta de nuevo.</string>
+    <string name="add_comment_error_server">No pudimos publicar tu comentario. Inténtalo de nuevo.</string>
+    <string name="add_comment_success">Comentario publicado</string>
 </resources>

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryAddCommentTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryAddCommentTest.kt
@@ -1,0 +1,90 @@
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.CommentDto
+import com.misw4203.vinilos.data.remote.dto.CreateCommentRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class AlbumRepositoryAddCommentTest {
+
+    private lateinit var api: VinilosApiService
+    private lateinit var dao: AlbumDao
+    private lateinit var repository: AlbumRepositoryImpl
+
+    @Before
+    fun setUp() {
+        api = mockk()
+        dao = mockk(relaxed = true)
+        repository = AlbumRepositoryImpl(api, dao)
+    }
+
+    @Test
+    fun `addComment posts request with collector ref and returns mapped Comment`() = runTest {
+        val capturedRequest = slot<CreateCommentRequest>()
+        coEvery { api.addComment(albumId = 1L, request = capture(capturedRequest)) } returns CommentDto(
+            id = 12L,
+            description = "Excelente álbum",
+            rating = 5,
+        )
+
+        val result = repository.addComment(
+            albumId = 1L,
+            description = "Excelente álbum",
+            rating = 5,
+            collectorId = 100,
+        )
+
+        assertEquals(12L, result.id)
+        assertEquals("Excelente álbum", result.description)
+        assertEquals(5, result.rating)
+
+        val sent = capturedRequest.captured
+        assertEquals("Excelente álbum", sent.description)
+        assertEquals(5, sent.rating)
+        assertEquals(100, sent.collector.id)
+
+        coVerify(exactly = 1) { api.addComment(albumId = 1L, request = any()) }
+    }
+
+    @Test
+    fun `addComment falls back to submitted rating when response rating is null`() = runTest {
+        coEvery { api.addComment(any(), any()) } returns CommentDto(
+            id = 7L,
+            description = "Texto",
+            rating = null,
+        )
+
+        val result = repository.addComment(albumId = 2L, description = "Texto", rating = 4, collectorId = 100)
+
+        assertEquals(4, result.rating)
+    }
+
+    @Test(expected = IOException::class)
+    fun `addComment propagates IOException`() = runTest {
+        coEvery { api.addComment(any(), any()) } throws IOException("offline")
+
+        repository.addComment(albumId = 1L, description = "x", rating = 3, collectorId = 100)
+    }
+
+    @Test(expected = HttpException::class)
+    fun `addComment propagates HttpException`() = runTest {
+        coEvery { api.addComment(any(), any()) } throws HttpException(
+            Response.error<Any>(400, "".toResponseBody("text/plain".toMediaType()))
+        )
+
+        repository.addComment(albumId = 1L, description = "x", rating = 3, collectorId = 100)
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/domain/usecase/AddCommentUseCaseTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/domain/usecase/AddCommentUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class AddCommentUseCaseTest {
+
+    private lateinit var repository: AlbumRepository
+    private lateinit var useCase: AddCommentUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = AddCommentUseCase(repository)
+    }
+
+    @Test
+    fun `invoke delegates to repository and returns mapped Comment`() = runTest {
+        val expected = Comment(id = 7L, description = "Buenísimo", rating = 5)
+        coEvery {
+            repository.addComment(albumId = 1L, description = "Buenísimo", rating = 5, collectorId = 100)
+        } returns expected
+
+        val result = useCase(albumId = 1L, description = "Buenísimo", rating = 5, collectorId = 100)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) {
+            repository.addComment(1L, "Buenísimo", 5, 100)
+        }
+    }
+
+    @Test(expected = IOException::class)
+    fun `invoke propagates IOException from repository`() = runTest {
+        coEvery { repository.addComment(any(), any(), any(), any()) } throws IOException("offline")
+
+        useCase(1L, "comentario", 4, 100)
+    }
+
+    @Test(expected = HttpException::class)
+    fun `invoke propagates HttpException from repository`() = runTest {
+        coEvery { repository.addComment(any(), any(), any(), any()) } throws HttpException(
+            Response.error<Any>(400, "".toResponseBody("text/plain".toMediaType()))
+        )
+
+        useCase(1L, "comentario", 4, 100)
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModelTest.kt
@@ -1,0 +1,223 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import com.misw4203.vinilos.domain.usecase.AddCommentUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddCommentViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeAlbumRepository : AlbumRepository {
+        var addCommentResult: Result<Comment> = Result.success(
+            Comment(id = 1L, description = "ok", rating = 5),
+        )
+        var lastArgs: AddCommentArgs? = null
+        var callCount = 0
+
+        override suspend fun getAlbums(): List<Album> = emptyList()
+        override suspend fun getAlbumById(id: Long): AlbumDetail = error("not used")
+        override suspend fun addComment(
+            albumId: Long,
+            description: String,
+            rating: Int,
+            collectorId: Int,
+        ): Comment {
+            callCount++
+            lastArgs = AddCommentArgs(albumId, description, rating, collectorId)
+            return addCommentResult.getOrThrow()
+        }
+    }
+
+    private data class AddCommentArgs(
+        val albumId: Long,
+        val description: String,
+        val rating: Int,
+        val collectorId: Int,
+    )
+
+    private fun buildViewModel(
+        repo: FakeAlbumRepository,
+        albumId: Long = 42L,
+        collectorId: Int = 100,
+    ): AddCommentViewModel {
+        val handle = SavedStateHandle(
+            mapOf(
+                Destinations.AddCommentAlbumArg to albumId,
+                Destinations.AddCommentCollectorArg to collectorId,
+            ),
+        )
+        return AddCommentViewModel(AddCommentUseCase(repo), handle)
+    }
+
+    @Test
+    fun `submit with valid form posts and emits Success`() = runTest {
+        val repo = FakeAlbumRepository().apply {
+            addCommentResult = Result.success(
+                Comment(id = 9L, description = "Excelente", rating = 5),
+            )
+        }
+        val viewModel = buildViewModel(repo)
+        viewModel.onDescriptionChange("Excelente")
+        viewModel.onRatingChange(5)
+
+        viewModel.uiState.test {
+            assertEquals(AddCommentUiState.Idle, awaitItem())
+            viewModel.submit()
+            assertEquals(AddCommentUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is AddCommentUiState.Success)
+            assertEquals(9L, (state as AddCommentUiState.Success).comment.id)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, repo.callCount)
+        assertEquals(
+            AddCommentArgs(albumId = 42L, description = "Excelente", rating = 5, collectorId = 100),
+            repo.lastArgs,
+        )
+    }
+
+    @Test
+    fun `submit with empty description sets descriptionError and does not call repo`() = runTest {
+        val repo = FakeAlbumRepository()
+        val viewModel = buildViewModel(repo)
+        viewModel.onRatingChange(4)
+        // description left blank
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val form = viewModel.form.value
+        assertEquals(FormError.EmptyDescription, form.descriptionError)
+        assertEquals(null, form.ratingError)
+        assertEquals(AddCommentUiState.Idle, viewModel.uiState.value)
+        assertEquals(0, repo.callCount)
+    }
+
+    @Test
+    fun `submit with rating zero sets ratingError and does not call repo`() = runTest {
+        val repo = FakeAlbumRepository()
+        val viewModel = buildViewModel(repo)
+        viewModel.onDescriptionChange("Buen álbum")
+        // rating left at 0
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val form = viewModel.form.value
+        assertEquals(FormError.InvalidRating, form.ratingError)
+        assertEquals(null, form.descriptionError)
+        assertEquals(AddCommentUiState.Idle, viewModel.uiState.value)
+        assertEquals(0, repo.callCount)
+    }
+
+    @Test
+    fun `submit emits network Error when repository throws IOException`() = runTest {
+        val repo = FakeAlbumRepository().apply {
+            addCommentResult = Result.failure(IOException("offline"))
+        }
+        val viewModel = buildViewModel(repo)
+        viewModel.onDescriptionChange("Buen álbum")
+        viewModel.onRatingChange(3)
+
+        viewModel.uiState.test {
+            assertEquals(AddCommentUiState.Idle, awaitItem())
+            viewModel.submit()
+            assertEquals(AddCommentUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddCommentUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `submit emits server Error when repository throws HttpException`() = runTest {
+        val repo = FakeAlbumRepository().apply {
+            addCommentResult = Result.failure(
+                HttpException(Response.error<Any>(400, "".toResponseBody("text/plain".toMediaType())))
+            )
+        }
+        val viewModel = buildViewModel(repo)
+        viewModel.onDescriptionChange("Buen álbum")
+        viewModel.onRatingChange(3)
+
+        viewModel.uiState.test {
+            assertEquals(AddCommentUiState.Idle, awaitItem())
+            viewModel.submit()
+            assertEquals(AddCommentUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddCommentUiState.Error(isNetworkError = false), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onRatingChange clamps values into the 0 to 5 range`() = runTest {
+        val repo = FakeAlbumRepository()
+        val viewModel = buildViewModel(repo)
+
+        viewModel.onRatingChange(99)
+        assertEquals(5, viewModel.form.value.rating)
+        viewModel.onRatingChange(-3)
+        assertEquals(0, viewModel.form.value.rating)
+        viewModel.onRatingChange(3)
+        assertEquals(3, viewModel.form.value.rating)
+    }
+
+    @Test
+    fun `onDescriptionChange and onRatingChange clear their respective errors`() = runTest {
+        val repo = FakeAlbumRepository()
+        val viewModel = buildViewModel(repo)
+        viewModel.submit() // both errors triggered
+        advanceUntilIdle()
+
+        assertNotNull(viewModel.form.value.descriptionError)
+        assertNotNull(viewModel.form.value.ratingError)
+
+        viewModel.onDescriptionChange("now filled")
+        assertEquals(null, viewModel.form.value.descriptionError)
+        assertNotNull(viewModel.form.value.ratingError)
+
+        viewModel.onRatingChange(4)
+        assertEquals(null, viewModel.form.value.ratingError)
+    }
+
+    @Test
+    fun `resetError moves Error state back to Idle`() = runTest {
+        val repo = FakeAlbumRepository().apply {
+            addCommentResult = Result.failure(IOException("offline"))
+        }
+        val viewModel = buildViewModel(repo)
+        viewModel.onDescriptionChange("Buen álbum")
+        viewModel.onRatingChange(3)
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertEquals(AddCommentUiState.Error(isNetworkError = true), viewModel.uiState.value)
+
+        viewModel.resetError()
+        assertEquals(AddCommentUiState.Idle, viewModel.uiState.value)
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AlbumDetailViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AlbumDetailViewModelTest.kt
@@ -34,6 +34,12 @@ class AlbumDetailViewModelTest {
         var detailResult: Result<AlbumDetail> = Result.success(sampleDetail())
         override suspend fun getAlbums(): List<Album> = emptyList()
         override suspend fun getAlbumById(id: Long): AlbumDetail = detailResult.getOrThrow()
+        override suspend fun addComment(
+            albumId: Long,
+            description: String,
+            rating: Int,
+            collectorId: Int,
+        ): Comment = Comment(0L, description, rating)
     }
 
     private fun buildViewModel(

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AlbumListViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AlbumListViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.misw4203.vinilos.MainDispatcherRule
 import com.misw4203.vinilos.domain.model.Album
 import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.Comment
 import com.misw4203.vinilos.domain.repository.AlbumRepository
 import com.misw4203.vinilos.domain.usecase.GetAlbumsUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,6 +34,12 @@ class AlbumListViewModelTest {
             return nextResult.getOrThrow()
         }
         override suspend fun getAlbumById(id: Long): AlbumDetail = error("not used")
+        override suspend fun addComment(
+            albumId: Long,
+            description: String,
+            rating: Int,
+            collectorId: Int,
+        ): Comment = error("not used")
     }
 
     private fun sampleAlbums() = listOf(


### PR DESCRIPTION
Summary

  - HU09 — Comentar un álbum: nuevo flujo POST /albums/{id}/comments con form de descripción y RatingBar interactivo de 5 estrellas, accesible desde
  AlbumDetailScreen. El detalle se refresca automáticamente al volver vía savedStateHandle.
  - Mejora estructural — contador de registros: subtítulo con total de items y orden alfa bajo cada LazyColumn (Albums, Artists, Collectors), inspirado en
  los wireframes de Claude Design.

  HU09 — Comentar álbum (commit 6551bd7)

  Capa data
  - CreateCommentRequest DTO con CollectorRef (campo collector obligatorio confirmado por Postman).
  - CommentDto extendido con collector: CollectorDto?.
  - VinilosApiService.addComment(albumId, request) (@POST("albums/{id}/comments")).
  - AlbumRepository.addComment(albumId, description, rating, collectorId) + impl que mapea respuesta a domain Comment.

  Capa domain
  - AddCommentUseCase que delega al repository.

  Capa presentation
  - AddCommentUiState (Idle/Loading/Success/Error) + AddCommentFormState + FormError.
  - AddCommentViewModel: _form y _uiState separados, SavedStateHandle para albumId y collectorId, validación local antes del POST, clasificación de
  excepciones (CancellationException re-lanzada, IOException → network, otros → server).
  - RatingBar reutilizable: 5 estrellas pulsables 36dp, testTag rating_star_{1..5}, contentDescription "n de 5 estrellas".
  - AddCommentScreen con Scaffold + CenterAlignedTopAppBar, OutlinedTextField (140dp min, contador 500 chars), Button 52dp con RoundedCornerShape(12dp) y
  loader, snackbars de éxito/error.

  Navegación
  - Ruta album/{albumId}/comment/add/{collectorId} en Destinations (con DefaultCollectorId = 100 mientras no exista auth).
  - Composable nuevo en VinilosNavHost. Refresco al volver mediante previousBackStackEntry.savedStateHandle[RefreshAlbumDetailKey] = true, observado en
  AlbumDetailScreen con LaunchedEffect(refreshKey).
  - Botón "+ Comentar" en AlbumDetailScreen con testTag album_detail_add_comment.

  Tests unitarios (14 nuevos)
  - AddCommentUseCaseTest (3): delegación, propagación de IOException y HttpException.
  - AddCommentViewModelTest (8): submit válido, descripción vacía, rating=0, error red, error servidor, clamp del rating, limpieza de errores, resetError.
  - AlbumRepositoryAddCommentTest (4): captura del CreateCommentRequest, fallback de rating, propagación de excepciones.

  Strings i18n: 12 strings nuevos para HU09 (sin texto hardcoded).

  testTags entregados: add_comment_screen, add_comment_back, add_comment_description, rating_star_1..5, add_comment_submit, album_detail_add_comment.

  Mejora — contador de registros (commit 4d88a8a)

  - Componente reutilizable ListCounter (labelSmall, color outline, testTag opcional).
  - Aplicado en AlbumListScreen, MusicianListScreen, CollectorListScreen con plurales i18n: R.plurals.{albums|artists|collectors}_record_count ("N álbumes ·
   orden alfa", etc.).
  - testTags: albums_record_count, artists_record_count, collectors_record_count.

  Validación

  - compileDebugKotlin ✅
  - assembleDebugAndroidTest ✅
  - Unit tests: toda la suite verde, sin regresiones.
  - Instrumented tests: 67/67 pasando en emulador API 34 (incluye VinilosE2ETest E2E con backend real en http://10.0.2.2:3000).

  Notas para el revisor

  - DefaultCollectorId = 100 es un placeholder hasta que se incorpore login. El backend rechaza el POST sin collector, así que se envía siempre.
  - Los fakes existentes (FakeAlbumRepository androidTest + 3 fakes inline en tests JVM) fueron actualizados para implementar el nuevo método del
  repository.
  - CollectorDetailScreen ya tenía la sección "Comentarios recientes" implementada previamente; no se duplicó.
  - El chip BANDA/MÚSICO en MusicianCard y la sección "Integrantes" en MusicianDetailScreen quedaron fuera de scope: requieren cambios de backend /
  endpoints adicionales.

  Test plan

  - Tab Álbumes → tarjeta → botón "+ Comentar" → form → rating 5 + texto + Publicar → snackbar éxito → volver → comentario aparece en el detalle.
  - Form sin descripción → error "El comentario no puede estar vacío".
  - Form con rating 0 → error "Selecciona una calificación de 1 a 5".
  - Sin red → snackbar "Sin conexión. Intenta de nuevo."
  - Listas Álbumes / Artistas / Coleccionistas muestran "N … · orden alfa" bajo el header.