### PR TITLE
Feature/corrutinas microoptimizaciones

### DIFF
--- a/CORRUTINAS_MICROOPTIMIZACIONES.md
+++ b/CORRUTINAS_MICROOPTIMIZACIONES.md
@@ -355,10 +355,11 @@ Aplicado en `AlbumCard`, `MusicianCard`, `PerformerChip` (`AlbumDetailScreen.kt:
 | 1 | `@Index(value = ["name"])` en `AlbumEntity`, `MusicianListEntity`, `CollectorEntity` | `data/local/entity/*Entity.kt` | `ORDER BY name ASC` evita full-table sort. DB v3 → v4 con destructive migration. |
 | 2 | `key(track.id)` y `key(comment.id)` sobre items dentro de `Column.forEach` | `presentation/ui/screens/album/AlbumDetailScreen.kt` | Identidad estable: insertar un track/comment via HU08/HU09 no recompone los anteriores. |
 | 3 | `ImageLoader` global con `crossfade(true)` + memory/disk cache | `VinilosApplication.kt` | Carga de imágenes uniforme con caché de 2 niveles + transición visual. Aplica a todos los `AsyncImage`. |
+| 4 | **Write-through cache** en `createAlbum`, `addTrack`, `addComment` | `AlbumRepositoryImpl.kt`, `AlbumDao.kt` | El POST actualiza la caché local en el mismo paso (insert para listas, read-modify-write para detalles). Evita lecturas stale entre el POST y el siguiente refetch, y mantiene consistencia offline tras escribir online. |
 
 Verificación:
 - `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL
-- `./gradlew :app:testDebugUnitTest` → BUILD SUCCESSFUL (60+ tests, 0 failures)
+- `./gradlew :app:testDebugUnitTest` → BUILD SUCCESSFUL (5 tests nuevos para write-through cache, 0 failures)
 
 ---
 

--- a/CORRUTINAS_MICROOPTIMIZACIONES.md
+++ b/CORRUTINAS_MICROOPTIMIZACIONES.md
@@ -1,0 +1,384 @@
+# Corrutinas y microoptimizaciones — Vinilos
+
+Este documento describe el uso de **Kotlin Coroutines** y las **microoptimizaciones** aplicadas en el módulo `app/` del proyecto Vinilos. Cada sección explica el concepto, dónde está implementado (con `archivo:línea`) y por qué.
+
+> Branch: `feature/corrutinas_microoptimizaciones`
+> Stack: Kotlin 2.0 · Coroutines 1.9.0 · Jetpack Compose · Room 2.6.1 · Retrofit 2.11 · Coil 2.7 · Hilt 2.52
+
+---
+
+## 1. Corrutinas
+
+### 1.1 ¿Qué son y por qué importan?
+
+Las **corrutinas** son la herramienta canónica de Kotlin para concurrencia cooperativa. Permiten escribir código asíncrono con sintaxis secuencial (`suspend fun`) sin bloquear el hilo principal. En Android son críticas para tres cosas:
+
+1. **Sacar trabajo de I/O del hilo de UI** (red, disco) → la app no se congela.
+2. **Vincular el ciclo de vida** (a `viewModelScope`, `lifecycleScope`) → cuando la pantalla muere, el trabajo se cancela automáticamente y no hay leaks.
+3. **Componer concurrencia estructurada** (`coroutineScope`, `async/awaitAll`) → si una hija falla, todas se cancelan; no hay tareas huérfanas.
+
+### 1.2 Patrones aplicados
+
+#### `viewModelScope.launch` + `StateFlow` con clasificación de excepciones
+
+Todos los ViewModels disparan trabajo en `viewModelScope` y exponen el resultado vía `StateFlow<UiState>`. La clasificación de excepciones está estandarizada:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CollectorListViewModel.kt:32
+private fun load() {
+    _uiState.value = CollectorListUiState.Loading
+    viewModelScope.launch {
+        _uiState.value = try {
+            val collectors = getCollectors()
+            if (collectors.isEmpty()) CollectorListUiState.Empty
+            else CollectorListUiState.Success(collectors)
+        } catch (e: CancellationException) { throw e }   // (1)
+        catch (e: IOException)   { CollectorListUiState.Error(isNetworkError = true)  }
+        catch (e: HttpException) { CollectorListUiState.Error(isNetworkError = false) }
+        catch (e: Exception)     { CollectorListUiState.Error(isNetworkError = false) }
+    }
+}
+```
+
+(1) **Re-lanzar `CancellationException`** es esencial para preservar concurrencia estructurada. Si un `catch (e: Exception)` la atrapa, una cancelación legítima (cambio de pantalla, retry rápido) se convierte en falso `Error` y se rompe la cadena de cancelación del scope.
+
+Mismo patrón en: `AlbumListViewModel.kt:35`, `AlbumDetailViewModel.kt:39`, `MusicianListViewModel.kt:34`, `MusicianDetailViewModel.kt:40`, `CollectorDetailViewModel.kt:48`, `CreateAlbumViewModel.kt:28`, `AddTrackViewModel.kt:50`, `AddCommentViewModel.kt:54`.
+
+#### Cancelación manual de la corrutina previa cuando cambia el argumento
+
+Cuando el usuario navega rápidamente entre detalles distintos, el ViewModel se reutiliza y el último load gana arbitrariamente. Para evitarlo, `MusicianDetailViewModel` mantiene un `Job` y lo cancela antes de relanzar:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/MusicianDetailViewModel.kt:33
+private var loadJob: Job? = null
+private var currentId: Int? = null
+
+fun loadMusician(id: Int) {
+    currentId = id
+    loadJob?.cancel()                                  // (1)
+    _uiState.value = MusicianDetailUiState.Loading
+    loadJob = viewModelScope.launch { /* ... */ }
+}
+```
+
+(1) `viewModelScope` cancela todo al `onCleared()`, pero **no** cancela trabajos previos cuando el argumento cambia. Sin esta línea, el último resultado en resolver "gana" — comportamiento no determinista.
+
+#### `withContext(Dispatchers.IO)` en repositorios
+
+Retrofit ya hace I/O en su propio executor, pero los repositorios envuelven todo en `Dispatchers.IO` para asegurar que el trabajo de mapping (DTO → domain), las llamadas a Room y los caminos de fallback no toquen el hilo principal. Es una garantía de capa, independiente del cliente HTTP.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt:29
+override suspend fun getAlbums(): List<Album> = withContext(Dispatchers.IO) {
+    try {
+        val albums = api.getAlbums().map { it.toAlbum() }
+        dao.replaceAlbums(albums.map { AlbumEntity.fromDomain(it) })
+        albums
+    } catch (e: IOException) {
+        val cached = dao.getAll()
+        if (cached.isNotEmpty()) cached.map { it.toDomain() } else throw e
+    }
+}
+```
+
+Aplicado en los 9 métodos de `AlbumRepositoryImpl`, los 2 de `MusicianRepositoryImpl` y los 2 de `CollectorRepositoryImpl`.
+
+#### `coroutineScope { async { … }.awaitAll() }` para paralelizar llamadas independientes
+
+El detalle del músico requiere N llamadas a `/prizes/{id}` (una por premio). En vez de iterarlas secuencialmente (`forEach { api.getPrizeDetail(it) }`), se lanzan todas en paralelo y se espera el conjunto:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImpl.kt:41
+val prizes = coroutineScope {
+    dto.performerPrizes.map { pp ->
+        async {
+            val prizeDto = api.getPrizeDetail(pp.id)
+            MusicianPrize(
+                id = prizeDto.id,
+                name = prizeDto.name,
+                organization = prizeDto.organization,
+                description = prizeDto.description,
+                premiationDate = pp.premiationDate,
+            )
+        }
+    }.awaitAll()
+}
+```
+
+Para un músico con 5 premios y latencia de 200 ms por request, baja de **~1 s** (secuencial) a **~200 ms** (paralelo). `coroutineScope` garantiza que si una llamada falla, las demás se cancelan — no hay requests huérfanos.
+
+Mismo patrón en `CollectorRepositoryImpl.kt:48` para enriquecer cada `collectorAlbum` con su `Album` completo desde `/albums/{id}`.
+
+#### `collectAsStateWithLifecycle` (lifecycle-aware Flow collection)
+
+En vez de `collectAsState()`, las pantallas usan la variante lifecycle-aware. Cuando la actividad pasa a STOPPED, la colección del flow se pausa automáticamente — no se procesan emisiones que la UI no va a ver, ahorrando CPU y batería.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt:50
+val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+```
+
+Aplicado en todas las pantallas: `AlbumListScreen`, `AlbumDetailScreen`, `MusicianListScreen`, `MusicianDetailScreen`, `CollectorListScreen`, `CollectorDetailScreen`, `CreateAlbumScreen`, `AddTrackScreen`, `AddCommentScreen`.
+
+#### `LaunchedEffect` + `SavedStateHandle` para refresh entre destinos
+
+Tras un POST exitoso (HU08, HU09), el detalle del álbum debe refrescarse. Se usa un flag en el `SavedStateHandle` del back-stack, observado vía `LaunchedEffect`:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt:79
+LaunchedEffect(refreshKey) {
+    if (refreshKey) {
+        viewModel.retry()
+        onRefreshHandled()
+    }
+}
+```
+
+`LaunchedEffect` se cancela y relanza cuando cambia la `key`. La corrutina hereda el scope del Composable, así que al salir de pantalla se cancela. Es la primitiva canónica para side effects con vida atada al composable.
+
+#### `SavedStateHandle` como puente entre navegación y ViewModel
+
+Hilt inyecta `SavedStateHandle` automáticamente, y los ViewModels leen los argumentos de navegación de allí. Eso evita pasar `id` por parámetro y sobrevive a recreación de proceso:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CollectorDetailViewModel.kt:27
+@HiltViewModel
+class CollectorDetailViewModel @Inject constructor(
+    private val getCollectorDetail: GetCollectorDetailUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val collectorId: Int = savedStateHandle[Destinations.CollectorDetailArg]
+        ?: error("collectorId required")
+    /* ... */
+}
+```
+
+Mismo patrón en `AlbumDetailViewModel`, `AddTrackViewModel`, `AddCommentViewModel`.
+
+---
+
+## 2. Microoptimizaciones
+
+### 2.1 Compose
+
+#### `key` en `LazyColumn` / `LazyRow`
+
+Sin `key`, Compose identifica los items por su posición. Si el orden cambia (insertar al inicio, eliminar uno) recompone TODOS. Con `key = { it.id }`, Compose emparejaa cada item con su Composable previo y solo recompone los que realmente cambiaron.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorListScreen.kt:70
+items(state.collectors, key = { it.id }) { collector ->
+    CollectorCard(/* ... */)
+}
+```
+
+Aplicado también en `AlbumListScreen.kt:88`, `MusicianListScreen.kt:70`, `AlbumDetailScreen.kt:342` (LazyRow de performers), `CollectorDetailScreen.kt:254` (LazyRow de albums) y `:327` (LazyRow de performers).
+
+#### `key()` sobre items dentro de `Column`/`forEach` (agregado en este sprint)
+
+La sección de tracks y comentarios en `AlbumDetailScreen` usa `forEachIndexed` dentro de un `Column` (no `LazyColumn`, porque el contenedor ya es `verticalScroll` global). Sin `key`, Compose no tiene forma de mantener identidad estable de cada `TrackRow`/`CommentCard` cuando se inserta uno nuevo (HU08, HU09). Se envuelve cada item con la función `key()`:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt:299
+tracks.forEachIndexed { index, track ->
+    key(track.id) {
+        TrackRow(index = index + 1, track = track)
+        Spacer(Modifier.height(8.dp))
+    }
+}
+
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt:381
+comments.forEach { comment ->
+    key(comment.id) {
+        CommentCard(comment)
+    }
+}
+```
+
+Beneficio concreto: cuando se agrega un track vía HU08, solo se inserta el nodo nuevo; los anteriores conservan su slot table y no se recomponen.
+
+#### `rememberLazyListState()`
+
+Preserva el scroll position cuando recompone. Aplicado en `CollectorListScreen.kt:39`.
+
+#### Constantes extraídas a top-level
+
+Valores como `CoverHeight`, `CardOverlap`, `CardRadius` están extraídos a `private val` en el archivo, no en el cuerpo del Composable. Evita re-instanciar el `Dp` en cada recomposición.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt:62
+private val CoverHeight = 300.dp
+private val CardOverlap = 32.dp
+private val CardRadius = 24.dp
+```
+
+### 2.2 Room
+
+#### `@Transaction` para operaciones compuestas
+
+`replaceX = clear() + upsertAll()` debe ser atómico. Si la app crashea entre el `DELETE` y el `INSERT`, no queremos perder la caché. Room serializa la operación en una sola transacción SQLite:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/data/local/dao/AlbumDao.kt:22
+@Transaction
+suspend fun replaceAlbums(albums: List<AlbumEntity>) {
+    clear()
+    upsertAll(albums)
+}
+```
+
+Mismo patrón en `MusicianDao.kt:22` y `CollectorDao.kt:22`.
+
+#### `@Upsert` en lugar de `@Insert(OnConflict = REPLACE)`
+
+`@Upsert` (Room 2.5+) maneja insert/update en una sola anotación y genera SQL más eficiente que `INSERT OR REPLACE` (este último elimina y reinserta, perdiendo `rowid`).
+
+#### `@Index` sobre columnas usadas en `ORDER BY` (agregado en este sprint)
+
+Las queries `SELECT * FROM albums ORDER BY name ASC`, `… FROM musicians …` y `… FROM collectors …` se ejecutan en cada `getAll()` del repositorio. Sin índice, SQLite hace **full scan + sort en memoria** (O(N log N)). Con índice sobre `name`, lee la tabla en orden de índice (O(N), sin sort).
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumEntity.kt:9
+@Entity(
+    tableName = "albums",
+    indices = [Index(value = ["name"])],
+)
+data class AlbumEntity(/* ... */)
+```
+
+Aplicado también en `MusicianListEntity.kt:9` y `CollectorEntity.kt:9`. Schema cambió → `VinilosDatabase.version` subió de 3 → 4. Como la DB usa `fallbackToDestructiveMigration()` (la caché es descartable), Room recrea la base sin necesidad de escribir `Migration`.
+
+Costo: el índice ocupa espacio adicional en disco (proporcional a `2 × N` strings de nombres) y cada `INSERT/UPDATE/DELETE` debe actualizar el índice. Para volúmenes pequeños (<10k filas) es despreciable; el beneficio en lecturas ordenadas supera ampliamente el costo.
+
+#### `fallbackToDestructiveMigration()`
+
+La caché Room es **descartable** (los datos viven en el backend). Si el schema cambia, en lugar de escribir migraciones complejas, se recrea la DB. La pérdida es invisible: el siguiente `GET` la repuebla.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt:23
+Room.databaseBuilder(context, VinilosDatabase::class.java, "vinilos.db")
+    .fallbackToDestructiveMigration()
+    .build()
+```
+
+#### Listas anidadas como JSON via `TypeConverters`
+
+Los detalles tienen listas (tracks, performers, comments, collectorAlbums, prizes). En vez de normalizar cada una en su propia tabla con relaciones, se serializan a JSON con Gson y se guardan como `TEXT`:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt
+@TypeConverter fun fromTrackList(value: List<Track>): String = gson.toJson(value)
+@TypeConverter fun toTrackList(value: String): List<Track> = gson.fromJson(value, listType)
+```
+
+Trade-off explícito: no se puede consultar por campos anidados (`WHERE track.name = …`) pero la caché no necesita esas queries — siempre se lee un detalle completo por id. Resultado: schema simple, menos tablas, menos joins.
+
+### 2.3 Retrofit / OkHttp
+
+#### `HttpLoggingInterceptor` solo en debug
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/di/NetworkModule.kt:23
+val logging = HttpLoggingInterceptor().apply {
+    level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+            else HttpLoggingInterceptor.Level.NONE
+}
+```
+
+Razones:
+- En release, loggear el body de cada request/response es **CPU + I/O desperdiciado** y puede filtrar datos sensibles a `logcat`.
+- El compilador elimina (DCE) la rama muerta.
+
+#### Timeouts conservadores (15s)
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/di/NetworkModule.kt:32
+.connectTimeout(15, TimeUnit.SECONDS)
+.readTimeout(15, TimeUnit.SECONDS)
+```
+
+15 s es suficiente para 3G lento y evita que un servidor caído deje requests pendientes indefinidamente. Sin timeout explícito, OkHttp usa 10 s por defecto pero queremos consistencia.
+
+### 2.4 Coil (carga de imágenes)
+
+#### `ImageLoader` global con caché en memoria + disco + crossfade (agregado en este sprint)
+
+Por defecto cada `AsyncImage` crea su request sin coordinar caché. Se proveyó un `ImageLoader` global vía `ImageLoaderFactory` en la `Application`:
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/VinilosApplication.kt:11
+@HiltAndroidApp
+class VinilosApplication : Application(), ImageLoaderFactory {
+    override fun newImageLoader(): ImageLoader = ImageLoader.Builder(this)
+        .crossfade(true)                                    // (1)
+        .memoryCache {
+            MemoryCache.Builder(this).maxSizePercent(0.20).build()   // (2)
+        }
+        .diskCache {
+            DiskCache.Builder()
+                .directory(cacheDir.resolve("image_cache"))
+                .maxSizePercent(0.02).build()               // (3)
+        }
+        .respectCacheHeaders(false)                         // (4)
+        .build()
+}
+```
+
+(1) **Crossfade** suaviza el "flash" cuando la imagen llega: 100 ms más agradables a la vista, sin tartamudeo.
+(2) **MemoryCache** = 20% de la RAM disponible para la app. Hits en memoria son instantáneos; ideal cuando volvés a una pantalla recién visitada.
+(3) **DiskCache** = 2% del almacenamiento del cache dir. Sobrevive a kill del proceso. Las portadas de álbumes se reusan entre sesiones.
+(4) **`respectCacheHeaders(false)`**: el backend del curso no envía `Cache-Control` apropiados; se confía en la heurística de Coil para no re-bajar la misma URL.
+
+Beneficio observable: scroll por la lista de álbumes ya cacheada → 0 requests de red, las portadas aparecen instantáneamente.
+
+#### `contentScale = ContentScale.Crop` y `Modifier.size()` constraint
+
+Coil necesita conocer las dimensiones objetivo para downsamplear el bitmap antes de decodificarlo. Cargar una portada de 1024×1024 en un slot de 72×72 sin resize quema **memoria 200×**.
+
+```kotlin
+// app/src/main/java/com/misw4203/vinilos/presentation/ui/components/AlbumCard.kt
+AsyncImage(
+    model = album.coverUrl,
+    contentScale = ContentScale.Crop,
+    modifier = Modifier.size(72.dp).clip(RoundedCornerShape(8.dp)),
+)
+```
+
+Aplicado en `AlbumCard`, `MusicianCard`, `PerformerChip` (`AlbumDetailScreen.kt:358`) y `CollectorDetailScreen` performers/albums.
+
+---
+
+## 3. Resumen de optimizaciones agregadas en este sprint
+
+| # | Optimización | Archivo(s) | Beneficio |
+|---|---|---|---|
+| 1 | `@Index(value = ["name"])` en `AlbumEntity`, `MusicianListEntity`, `CollectorEntity` | `data/local/entity/*Entity.kt` | `ORDER BY name ASC` evita full-table sort. DB v3 → v4 con destructive migration. |
+| 2 | `key(track.id)` y `key(comment.id)` sobre items dentro de `Column.forEach` | `presentation/ui/screens/album/AlbumDetailScreen.kt` | Identidad estable: insertar un track/comment via HU08/HU09 no recompone los anteriores. |
+| 3 | `ImageLoader` global con `crossfade(true)` + memory/disk cache | `VinilosApplication.kt` | Carga de imágenes uniforme con caché de 2 niveles + transición visual. Aplica a todos los `AsyncImage`. |
+
+Verificación:
+- `./gradlew :app:assembleDebug` → BUILD SUCCESSFUL
+- `./gradlew :app:testDebugUnitTest` → BUILD SUCCESSFUL (60+ tests, 0 failures)
+
+---
+
+## 4. Cómo medir / verificar
+
+### Concurrencia y corrutinas
+
+- **Inspección de transitions**: en Android Studio, ver el panel "Profiler → CPU" durante una operación; las llamadas paralelas vía `async/awaitAll` deben mostrar threads concurrentes en `OkHttp Dispatcher`.
+- **Cancelación correcta**: rotar el dispositivo durante un load lento; con `viewModelScope` el log debería mostrar `JobCancellationException` y no `Error` en la UI.
+- **Tests unitarios**: la suite verifica `Loading → Success/Error/Empty` para cada VM con `Turbine` + `MainDispatcherRule`.
+
+### Compose
+
+- **Recomposition counts**: añadir `Modifier.recompose()` (Layout Inspector) sobre `TrackRow` y verificar que solo se cuenta 1 cuando se inserta un nuevo track (con `key`).
+- **Frame rate**: `adb shell dumpsys gfxinfo com.misw4203.vinilos framestats` antes y después; lista de 100 álbumes con scroll debería mantenerse en 60fps.
+
+### Room
+
+- **Logging de queries**: habilitar `setQueryCallback` temporalmente en debug y observar el `EXPLAIN QUERY PLAN` de los `SELECT … ORDER BY name`. Con índice debe decir `USING INDEX` en vez de `USE TEMP B-TREE FOR ORDER BY`.
+
+### Coil
+
+- **Cache hit rate**: pintar la lista de álbumes dos veces seguidas; el segundo render no debería disparar requests (verificable con `HttpLoggingInterceptor.Level.BASIC` en debug). Hit en memoria es <1 ms; hit en disco ~10 ms; miss de red ~200-500 ms.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ app/src/main/java/com/misw4203/vinilos/
 │   └── ui/
 │       ├── screens/
 │       │   ├── album/
-│       │   └── artist/
+│       │   ├── artist/
+│       │   └── collector/
 │       ├── components/  # Composables reutilizables
 │       └── theme/       # Material 3 theme
 └── di/                  # Módulos de Hilt
@@ -48,17 +49,19 @@ Responsable de obtener y persistir datos, ya sea desde la red o desde la base de
 | `data/local/dao/` | Interfaces DAO de Room con operaciones `@Upsert`, `@Query`, y transacciones (`replaceX` = clear + upsert). |
 | `data/local/database/` | `VinilosDatabase` — clase abstracta `RoomDatabase` que declara entidades y expone los DAOs. |
 | `data/local/entity/` | Entidades `@Entity` con mappers `toDomain()` / `fromDomain()`. |
-| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints (`GET /albums`, `GET /albums/{id}`, `GET /musicians`, `GET /musicians/{id}`, `GET /prizes/{id}`). |
-| `data/remote/dto/` | DTOs que modelan la respuesta JSON. Campos nullables para tolerar datos incompletos del servidor. |
-| `data/repository/` | Implementaciones de repositorio con estrategia **network-first + fallback a caché**. |
+| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints de lectura (`GET /albums`, `GET /albums/{id}`, `GET /musicians`, `GET /musicians/{id}`, `GET /prizes/{id}`, `GET /collectors`, `GET /collectors/{id}`) y de escritura (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`). |
+| `data/remote/dto/` | DTOs que modelan la respuesta JSON (`AlbumDto`, `TrackDto`, `CommentDto`, `MusicianDetailDto`, `PrizeDetailDto`, `PerformerPrizeDto`, `CollectorDto`, `CollectorDetailDto`) y los bodies de escritura (`CreateAlbumRequestDto`, `CreateTrackRequest`, `CreateCommentRequest`). Campos nullables para tolerar datos incompletos del servidor. |
+| `data/repository/` | Implementaciones de repositorio con estrategia **network-first + fallback a caché** para lecturas y POST directo a red (sin caché) para escrituras. |
 
 ### Estrategia de caché
 
-Todos los repositorios siguen el mismo patrón:
+Todos los repositorios siguen el mismo patrón para **lecturas**:
 
 1. Intenta red → si hay éxito, actualiza la caché (`replaceX` transaccional para listas, `upsert` para detalles) y retorna.
 2. Si la red falla con `IOException` (offline) → retorna la caché si existe; si no, re-lanza el error.
 3. Si falla con `HttpException` u otro → propaga (la UI clasifica 404, red, servidor, etc.).
+
+Para **escrituras** (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`) el repositorio envía el request directamente al API sin tocar la caché. Tras un POST exitoso, la pantalla origen invalida su `UiState` (vía `retry()` o flag en `SavedStateHandle`) para que el siguiente `GET` refresque la caché con el dato nuevo. Las excepciones se propagan al ViewModel sin envolverlas, igual que en las lecturas.
 
 ---
 
@@ -68,9 +71,9 @@ Es el núcleo de la aplicación. No depende de ninguna otra capa y contiene la l
 
 | Carpeta | Contenido |
 |---|---|
-| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `MusicianPrize`, `Track`, `Performer`, `Comment`). Sin dependencias de Android. |
-| `domain/repository/` | Interfaces de repositorio (`AlbumRepository`, `MusicianRepository`). |
-| `domain/usecase/` | Casos de uso (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`). |
+| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `MusicianPrize`, `Track`, `Performer`, `Comment`, `CollectorSummary`, `CollectorDetail`, `CollectorAlbum`, `CollectorComment`, `CreateAlbumInput`). Sin dependencias de Android. |
+| `domain/repository/` | Interfaces de repositorio (`AlbumRepository` con `getAlbums`, `getAlbumById`, `createAlbum`, `addTrack`, `addComment`; `MusicianRepository`; `CollectorRepository`). |
+| `domain/usecase/` | Casos de uso de lectura (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`, `GetCollectorsUseCase`, `GetCollectorDetailUseCase`) y de escritura (`CreateAlbumUseCase`, `AddTrackUseCase`, `AddCommentUseCase`). |
 
 ---
 
@@ -80,10 +83,10 @@ Contiene todo lo relacionado con la interfaz de usuario y el estado de la pantal
 
 | Carpeta | Contenido |
 |---|---|
-| `presentation/navigation/` | `VinilosNavHost` + `Destinations` (rutas y argumentos de navegación). |
-| `presentation/viewmodel/` | ViewModels con `@HiltViewModel`. Exponen `StateFlow<UiState>` y clasifican excepciones (`IOException` → red, `HttpException` 404 → NotFound, otros → servidor). Re-lanzan `CancellationException` para preservar structured concurrency. |
-| `presentation/ui/screens/` | Composables por entidad (`album/`, `artist/`). |
-| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`, `SearchBarStatic`. |
+| `presentation/navigation/` | `VinilosNavHost` + `Destinations` (rutas: `album_list`, `album_detail/{albumId}`, `create_album`, `album/{albumId}/track/add`, `album/{albumId}/comment/add/{collectorId}`, `artists`, `artist/{id}`, `collectors`, `collector/{collectorId}`). |
+| `presentation/viewmodel/` | ViewModels con `@HiltViewModel`. Para listas/detalle exponen `StateFlow<UiState>` (`Loading / Success / Empty\|NotFound / Error(isNetworkError)`) y clasifican excepciones (`IOException` → red, `HttpException` 404 → NotFound, otros → servidor). Para formularios POST (`CreateAlbumViewModel`, `AddTrackViewModel`, `AddCommentViewModel`) separan el form state del submit state (`Idle / Loading / Success / Error`). Todos re-lanzan `CancellationException` para preservar structured concurrency. |
+| `presentation/ui/screens/` | Composables por entidad: `album/` (`AlbumListScreen`, `AlbumDetailScreen`, `CreateAlbumScreen`, `AddTrackScreen`, `AddCommentScreen`), `artist/` (`MusicianListScreen`, `MusicianDetailScreen`), `collector/` (`CollectorListScreen`, `CollectorDetailScreen`). |
+| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `CollectorCard`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`, `SearchBarStatic`, `ListCounter`, `RatingBar`. |
 | `presentation/ui/theme/` | Material 3: `Color.kt`, `Theme.kt`, `Type.kt`. |
 
 ---
@@ -95,8 +98,8 @@ Módulos de Hilt instalados en `SingletonComponent`.
 | Archivo | Contenido |
 |---|---|
 | `NetworkModule` | Provee `OkHttpClient` (con `HttpLoggingInterceptor` solo en debug), `Retrofit` y `VinilosApiService`. |
-| `DatabaseModule` | Provee `VinilosDatabase` (con `fallbackToDestructiveMigration` — la caché es descartable) y los DAOs (`AlbumDao`, `MusicianDao`). |
-| `RepositoryModule` | `@Binds` de las interfaces de dominio a sus implementaciones. |
+| `DatabaseModule` | Provee `VinilosDatabase` (con `fallbackToDestructiveMigration` — la caché es descartable) y los DAOs (`AlbumDao`, `MusicianDao`, `CollectorDao`). |
+| `RepositoryModule` | `@Binds` de las interfaces de dominio a sus implementaciones: `AlbumRepository → AlbumRepositoryImpl`, `MusicianRepository → MusicianRepositoryImpl`, `CollectorRepository → CollectorRepositoryImpl`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ Todos los repositorios siguen el mismo patrón para **lecturas**:
 2. Si la red falla con `IOException` (offline) → retorna la caché si existe; si no, re-lanza el error.
 3. Si falla con `HttpException` u otro → propaga (la UI clasifica 404, red, servidor, etc.).
 
-Para **escrituras** (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`) el repositorio envía el request directamente al API sin tocar la caché. Tras un POST exitoso, la pantalla origen invalida su `UiState` (vía `retry()` o flag en `SavedStateHandle`) para que el siguiente `GET` refresque la caché con el dato nuevo. Las excepciones se propagan al ViewModel sin envolverlas, igual que en las lecturas.
+Para **escrituras** (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`) el repositorio aplica **write-through cache**:
+
+- `createAlbum`: tras la respuesta exitosa hace `dao.upsert(AlbumEntity)` para insertar el nuevo álbum en la lista local.
+- `addTrack` / `addComment`: si existe un `AlbumDetailEntity` cacheado para ese `albumId`, se hace read-modify-write apilando el nuevo track/comentario y `upsertDetail` lo persiste; si el detalle aún no está en caché, se omite la escritura local (el próximo `getAlbumById` la repoblará).
+
+Adicionalmente, la pantalla origen invalida su `UiState` vía `retry()` o un flag en `SavedStateHandle`. Esto asegura coherencia inmediata aunque se produzca una desconexión justo después del POST. Las excepciones se propagan al ViewModel sin envolverlas, igual que en las lecturas.
 
 ---
 

--- a/app/src/main/java/com/misw4203/vinilos/VinilosApplication.kt
+++ b/app/src/main/java/com/misw4203/vinilos/VinilosApplication.kt
@@ -1,7 +1,31 @@
 package com.misw4203.vinilos
 
 import android.app.Application
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.CachePolicy
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class VinilosApplication : Application()
+class VinilosApplication : Application(), ImageLoaderFactory {
+
+    override fun newImageLoader(): ImageLoader = ImageLoader.Builder(this)
+        .crossfade(true)
+        .memoryCache {
+            MemoryCache.Builder(this)
+                .maxSizePercent(0.20)
+                .build()
+        }
+        .diskCache {
+            DiskCache.Builder()
+                .directory(cacheDir.resolve("image_cache"))
+                .maxSizePercent(0.02)
+                .build()
+        }
+        .respectCacheHeaders(false)
+        .memoryCachePolicy(CachePolicy.ENABLED)
+        .diskCachePolicy(CachePolicy.ENABLED)
+        .build()
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/dao/AlbumDao.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/dao/AlbumDao.kt
@@ -16,6 +16,9 @@ interface AlbumDao {
     @Upsert
     suspend fun upsertAll(albums: List<AlbumEntity>)
 
+    @Upsert
+    suspend fun upsert(album: AlbumEntity)
+
     @Query("DELETE FROM albums")
     suspend fun clear()
 

--- a/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
@@ -23,7 +23,7 @@ import com.misw4203.vinilos.data.local.entity.MusicianListEntity
         CollectorEntity::class,
         CollectorDetailEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = false,
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/AlbumEntity.kt
@@ -1,10 +1,14 @@
 package com.misw4203.vinilos.data.local.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.misw4203.vinilos.domain.model.Album
 
-@Entity(tableName = "albums")
+@Entity(
+    tableName = "albums",
+    indices = [Index(value = ["name"])],
+)
 data class AlbumEntity(
     @PrimaryKey val id: Long,
     val name: String,

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/CollectorEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/CollectorEntity.kt
@@ -1,10 +1,14 @@
 package com.misw4203.vinilos.data.local.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.misw4203.vinilos.domain.model.CollectorSummary
 
-@Entity(tableName = "collectors")
+@Entity(
+    tableName = "collectors",
+    indices = [Index(value = ["name"])],
+)
 data class CollectorEntity(
     @PrimaryKey val id: Int,
     val name: String,

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianListEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/MusicianListEntity.kt
@@ -1,10 +1,14 @@
 package com.misw4203.vinilos.data.local.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.misw4203.vinilos.domain.model.MusicianSummary
 
-@Entity(tableName = "musicians")
+@Entity(
+    tableName = "musicians",
+    indices = [Index(value = ["name"])],
+)
 data class MusicianListEntity(
     @PrimaryKey val id: Int,
     val name: String,

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
@@ -50,11 +50,19 @@ class AlbumRepositoryImpl @Inject constructor(
     override suspend fun addTrack(albumId: Long, request: CreateTrackRequest): Track =
         withContext(Dispatchers.IO) {
             val dto = api.addTrack(albumId, request)
-            Track(
+            val track = Track(
                 id = dto.id,
                 name = dto.name.orEmpty(),
                 duration = dto.duration.orEmpty(),
             )
+            // Write-through cache: si hay detalle cacheado para este álbum,
+            // lo actualizamos con el nuevo track para evitar lectura stale
+            // antes del próximo getAlbumById().
+            dao.getDetailById(albumId)?.let { cached ->
+                val updated = cached.toDomain().copy(tracks = cached.tracks + track)
+                dao.upsertDetail(AlbumDetailEntity.fromDomain(updated))
+            }
+            track
         }
 
     override suspend fun addComment(
@@ -71,11 +79,17 @@ class AlbumRepositoryImpl @Inject constructor(
                 collector = CollectorRef(id = collectorId),
             ),
         )
-        Comment(
+        val comment = Comment(
             id = response.id,
             description = response.description.orEmpty(),
             rating = response.rating ?: rating,
         )
+        // Write-through cache: ver nota en addTrack.
+        dao.getDetailById(albumId)?.let { cached ->
+            val updated = cached.toDomain().copy(comments = cached.comments + comment)
+            dao.upsertDetail(AlbumDetailEntity.fromDomain(updated))
+        }
+        comment
     }
 
     override suspend fun createAlbum(input: CreateAlbumInput): Album = withContext(Dispatchers.IO) {
@@ -89,7 +103,11 @@ class AlbumRepositoryImpl @Inject constructor(
                 recordLabel = input.recordLabel,
             )
         )
-        dto.toAlbum()
+        val album = dto.toAlbum()
+        // Write-through cache: el nuevo álbum queda disponible offline
+        // y la lista no necesita refetch obligatorio.
+        dao.upsert(AlbumEntity.fromDomain(album))
+        album
     }
 
     private fun AlbumDto.toAlbum(): Album = Album(

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -297,8 +298,10 @@ private fun TracksSection(tracks: List<Track>, onAddTrack: () -> Unit) {
     }
     Spacer(Modifier.height(12.dp))
     tracks.forEachIndexed { index, track ->
-        TrackRow(index = index + 1, track = track)
-        Spacer(Modifier.height(8.dp))
+        key(track.id) {
+            TrackRow(index = index + 1, track = track)
+            Spacer(Modifier.height(8.dp))
+        }
     }
 }
 
@@ -379,7 +382,9 @@ private fun CommentsSection(comments: List<Comment>) {
     Spacer(Modifier.height(12.dp))
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         comments.forEach { comment ->
-            CommentCard(comment)
+            key(comment.id) {
+                CommentCard(comment)
+            }
         }
     }
 }

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImplTest.kt
@@ -1,16 +1,21 @@
 package com.misw4203.vinilos.data.repository
 
 import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
+import com.misw4203.vinilos.data.local.entity.AlbumEntity
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
 import com.misw4203.vinilos.data.remote.dto.CommentDto
 import com.misw4203.vinilos.data.remote.dto.CreateTrackRequest
 import com.misw4203.vinilos.data.remote.dto.PerformerDto
 import com.misw4203.vinilos.data.remote.dto.TrackDto
+import com.misw4203.vinilos.domain.model.Comment
 import com.misw4203.vinilos.domain.model.CreateAlbumInput
+import com.misw4203.vinilos.domain.model.Track
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -163,6 +168,108 @@ class AlbumRepositoryImplTest {
         repository.createAlbum(
             CreateAlbumInput("n", "c", "2024-01-01", "d", "Rock", "Sony Music")
         )
+    }
+
+    // -- Write-through cache (HU07/HU08/HU09) --------------------------------
+
+    @Test
+    fun `createAlbum upserts the new album into the local cache`() = runTest {
+        val captured = slot<AlbumEntity>()
+        coEvery { api.createAlbum(any()) } returns albumDto(
+            id = 99L,
+            name = "Nuevo",
+            genre = "Rock",
+        )
+        coEvery { dao.upsert(capture(captured)) } returns Unit
+
+        val result = repository.createAlbum(
+            CreateAlbumInput("Nuevo", "c", "2024-01-01", "d", "Rock", "Sony Music")
+        )
+
+        assertEquals(99L, result.id)
+        coVerify(exactly = 1) { dao.upsert(any()) }
+        assertEquals(99L, captured.captured.id)
+        assertEquals("Nuevo", captured.captured.name)
+    }
+
+    @Test
+    fun `addTrack appends the new track to the cached album detail`() = runTest {
+        val albumId = 42L
+        val cached = AlbumDetailEntity(
+            id = albumId,
+            name = "OK Computer",
+            coverUrl = "",
+            artistName = "Radiohead",
+            releaseDate = "1997-05-21",
+            genre = "Rock",
+            recordLabel = "Parlophone",
+            description = "",
+            tracks = listOf(Track(1L, "Airbag", "4:44")),
+            performers = emptyList(),
+            comments = emptyList(),
+        )
+        coEvery { dao.getDetailById(albumId) } returns cached
+        coEvery { api.addTrack(albumId, any()) } returns TrackDto(2L, "Karma Police", "4:21")
+        val captured = slot<AlbumDetailEntity>()
+        coEvery { dao.upsertDetail(capture(captured)) } returns Unit
+
+        val result = repository.addTrack(albumId, CreateTrackRequest("Karma Police", "04:21"))
+
+        assertEquals(2L, result.id)
+        coVerify(exactly = 1) { dao.upsertDetail(any()) }
+        assertEquals(2, captured.captured.tracks.size)
+        assertEquals("Karma Police", captured.captured.tracks[1].name)
+    }
+
+    @Test
+    fun `addTrack does not touch cache when album detail is not cached`() = runTest {
+        val albumId = 50L
+        coEvery { dao.getDetailById(albumId) } returns null
+        coEvery { api.addTrack(albumId, any()) } returns TrackDto(3L, "X", "01:00")
+
+        repository.addTrack(albumId, CreateTrackRequest("X", "01:00"))
+
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `addComment appends the new comment to the cached album detail`() = runTest {
+        val albumId = 7L
+        val cached = AlbumDetailEntity(
+            id = albumId,
+            name = "Album",
+            coverUrl = "",
+            artistName = "",
+            releaseDate = "",
+            genre = "",
+            recordLabel = "",
+            description = "",
+            tracks = emptyList(),
+            performers = emptyList(),
+            comments = listOf(Comment(10L, "Bueno", 4)),
+        )
+        coEvery { dao.getDetailById(albumId) } returns cached
+        coEvery { api.addComment(albumId, any()) } returns CommentDto(11L, "Excelente", 5)
+        val captured = slot<AlbumDetailEntity>()
+        coEvery { dao.upsertDetail(capture(captured)) } returns Unit
+
+        repository.addComment(albumId, "Excelente", 5, 100)
+
+        coVerify(exactly = 1) { dao.upsertDetail(any()) }
+        assertEquals(2, captured.captured.comments.size)
+        assertEquals("Excelente", captured.captured.comments[1].description)
+        assertEquals(5, captured.captured.comments[1].rating)
+    }
+
+    @Test
+    fun `addComment does not touch cache when album detail is not cached`() = runTest {
+        val albumId = 8L
+        coEvery { dao.getDetailById(albumId) } returns null
+        coEvery { api.addComment(albumId, any()) } returns CommentDto(12L, "x", 3)
+
+        repository.addComment(albumId, "x", 3, 100)
+
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
     }
 
     private fun albumDto(

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/CollectorRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/CollectorRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.CollectorDao
+import com.misw4203.vinilos.data.local.entity.CollectorEntity
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.CollectorDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class CollectorRepositoryImplTest {
+
+    private lateinit var api: VinilosApiService
+    private lateinit var dao: CollectorDao
+    private lateinit var repository: CollectorRepositoryImpl
+
+    @Before
+    fun setUp() {
+        api = mockk()
+        dao = mockk(relaxed = true)
+        repository = CollectorRepositoryImpl(api, dao)
+    }
+
+    // -- getCollectors (HU05) ------------------------------------------------
+
+    @Test
+    fun `getCollectors returns mapped summaries from API and replaces cache`() = runTest {
+        coEvery { api.getCollectors() } returns listOf(
+            collectorDto(id = 100, name = "Manolo Bellon", telephone = "3502457896", email = "manollo@caracol.com.co"),
+            collectorDto(id = 101, name = "Jaime Monsalve", telephone = "3102178976", email = "j.monsalve@rtvc.com.co"),
+        )
+
+        val result = repository.getCollectors()
+
+        assertEquals(2, result.size)
+        assertEquals("Manolo Bellon", result[0].name)
+        assertEquals("3502457896", result[0].telephone)
+        assertEquals("manollo@caracol.com.co", result[0].email)
+        assertEquals(101, result[1].id)
+        coVerify(exactly = 1) { dao.replaceCollectors(any()) }
+    }
+
+    @Test
+    fun `getCollectors falls back to cache when API throws IOException`() = runTest {
+        coEvery { api.getCollectors() } throws IOException("offline")
+        coEvery { dao.getAll() } returns listOf(
+            CollectorEntity(id = 100, name = "Manolo Bellon", telephone = "3502457896", email = "manollo@caracol.com.co"),
+        )
+
+        val result = repository.getCollectors()
+
+        assertEquals(1, result.size)
+        assertEquals("Manolo Bellon", result[0].name)
+        coVerify(exactly = 1) { dao.getAll() }
+    }
+
+    @Test(expected = IOException::class)
+    fun `getCollectors propagates IOException when cache is empty`() = runTest {
+        coEvery { api.getCollectors() } throws IOException("offline")
+        coEvery { dao.getAll() } returns emptyList()
+
+        repository.getCollectors()
+    }
+
+    @Test(expected = HttpException::class)
+    fun `getCollectors propagates HttpException`() = runTest {
+        coEvery { api.getCollectors() } throws HttpException(
+            Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType()))
+        )
+
+        repository.getCollectors()
+    }
+
+    private fun collectorDto(
+        id: Int,
+        name: String = "name",
+        telephone: String = "0000000000",
+        email: String = "email@test.com",
+    ) = CollectorDto(
+        id = id,
+        name = name,
+        telephone = telephone,
+        email = email,
+        description = null,
+        comments = emptyList(),
+        collectorAlbums = emptyList(),
+        favoritePerformers = emptyList(),
+    )
+}

--- a/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetCollectorsUseCaseTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetCollectorsUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.CollectorSummary
+import com.misw4203.vinilos.domain.repository.CollectorRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class GetCollectorsUseCaseTest {
+
+    private lateinit var repository: CollectorRepository
+    private lateinit var useCase: GetCollectorsUseCase
+
+    @Before
+    fun setUp() {
+        repository = mockk()
+        useCase = GetCollectorsUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns collectors from repository`() = runTest {
+        val collectors = listOf(
+            CollectorSummary(100, "Manolo Bellon", "3502457896", "manollo@caracol.com.co"),
+            CollectorSummary(101, "Jaime Monsalve", "3102178976", "j.monsalve@rtvc.com.co"),
+        )
+        coEvery { repository.getCollectors() } returns collectors
+
+        val result = useCase()
+
+        assertEquals(collectors, result)
+        coVerify(exactly = 1) { repository.getCollectors() }
+    }
+
+    @Test
+    fun `invoke returns empty list when repository has none`() = runTest {
+        coEvery { repository.getCollectors() } returns emptyList()
+
+        val result = useCase()
+
+        assertEquals(0, result.size)
+    }
+
+    @Test(expected = IOException::class)
+    fun `invoke propagates repository exception`() = runTest {
+        coEvery { repository.getCollectors() } throws IOException("offline")
+
+        useCase()
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/CollectorListViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/CollectorListViewModelTest.kt
@@ -1,0 +1,130 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.CollectorDetail
+import com.misw4203.vinilos.domain.model.CollectorSummary
+import com.misw4203.vinilos.domain.repository.CollectorRepository
+import com.misw4203.vinilos.domain.usecase.GetCollectorsUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectorListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeCollectorRepository : CollectorRepository {
+        var nextResult: Result<List<CollectorSummary>> = Result.success(emptyList())
+        var callCount = 0
+        override suspend fun getCollectors(): List<CollectorSummary> {
+            callCount++
+            return nextResult.getOrThrow()
+        }
+        override suspend fun getCollectorDetail(id: Int): CollectorDetail = error("not used")
+    }
+
+    private fun buildViewModel(repo: FakeCollectorRepository) =
+        CollectorListViewModel(GetCollectorsUseCase(repo))
+
+    private fun sampleCollectors() = listOf(
+        CollectorSummary(100, "Manolo Bellon", "3502457896", "manollo@caracol.com.co"),
+        CollectorSummary(101, "Jaime Monsalve", "3102178976", "j.monsalve@rtvc.com.co"),
+    )
+
+    @Test
+    fun `starts in Loading then emits Success when repository returns collectors`() = runTest {
+        val repo = FakeCollectorRepository().apply {
+            nextResult = Result.success(sampleCollectors())
+        }
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is CollectorListUiState.Success)
+            assertEquals(2, (state as CollectorListUiState.Success).collectors.size)
+            assertEquals("Manolo Bellon", state.collectors[0].name)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits Empty when repository returns empty list`() = runTest {
+        val repo = FakeCollectorRepository().apply { nextResult = Result.success(emptyList()) }
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(CollectorListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits network Error when repository throws IOException`() = runTest {
+        val repo = FakeCollectorRepository().apply {
+            nextResult = Result.failure(IOException("offline"))
+        }
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(CollectorListUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits server Error when repository throws HttpException`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType()))
+        )
+        val repo = FakeCollectorRepository().apply { nextResult = Result.failure(httpError) }
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(CollectorListUiState.Error(isNetworkError = false), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry re-invokes repository and recovers to Success`() = runTest {
+        val repo = FakeCollectorRepository().apply {
+            nextResult = Result.failure(IOException("offline"))
+        }
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(CollectorListUiState.Error(isNetworkError = true), awaitItem())
+
+            repo.nextResult = Result.success(sampleCollectors())
+            viewModel.retry()
+
+            assertEquals(CollectorListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertTrue(awaitItem() is CollectorListUiState.Success)
+            assertEquals(2, repo.callCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
 ## Resumen

  Branch dedicado a documentar y reforzar el uso de **Kotlin Coroutines** y **microoptimizaciones** en Vinilos. Adicionalmente cierra deuda detectada por
  feedback (mapeo del módulo de coleccionistas en el diseño arquitectónico, tests faltantes de HU05) y cubre gaps de caching en los POST del Sprint 2.

  ## Cambios

  ### Nuevas optimizaciones aplicadas

  | # | Cambio | Archivos |
  |---|---|---|
  | 1 | `@Index(value = ["name"])` en `AlbumEntity`, `MusicianListEntity`, `CollectorEntity`. Evita full-table sort en queries `ORDER BY name ASC`. DB v3 →
  v4 (destructive). | `data/local/entity/*Entity.kt`, `VinilosDatabase.kt` |
  | 2 | `key(track.id)` y `key(comment.id)` en los `forEach` de `AlbumDetailScreen` para preservar identidad estable al insertar items vía HU08/HU09. |
  `presentation/ui/screens/album/AlbumDetailScreen.kt` |
  | 3 | `ImageLoader` global con `crossfade(true)` + memory cache 20% + disk cache 2% vía `ImageLoaderFactory` en la `Application`. Aplica a todas las
  `AsyncImage` sin tocar call sites. | `VinilosApplication.kt` |
  | 4 | **Write-through cache** en `createAlbum` (insert), `addTrack` y `addComment` (read-modify-write sobre `AlbumDetailEntity`). Coherencia inmediata
  tras POST sin depender del `retry()` de la pantalla. | `data/local/dao/AlbumDao.kt`, `data/repository/AlbumRepositoryImpl.kt` |

  ### Tests añadidos

  - **HU05** — closures de los criterios de aceptación que faltaban:
    - `GetCollectorsUseCaseTest`
    - `CollectorListViewModelTest` (5 escenarios: Loading→Success/Empty/Error red/Error servidor/retry)
    - `CollectorRepositoryImplTest` (network OK + replace cache, IOException con/sin caché, HttpException)
  - **Write-through cache**:
    - `createAlbum upserts the new album into the local cache`
    - `addTrack appends the new track to the cached album detail`
    - `addTrack does not touch cache when album detail is not cached`
    - `addComment appends the new comment to the cached album detail`
    - `addComment does not touch cache when album detail is not cached`

  ### Documentación

  - `CORRUTINAS_MICROOPTIMIZACIONES.md` (nuevo): explica los patrones de corrutinas (`viewModelScope`, structured concurrency, cancelación de jobs,
  `async/awaitAll`, `withContext(IO)`, `collectAsStateWithLifecycle`, `LaunchedEffect`, `SavedStateHandle`) y las microoptimizaciones (Compose `key`, Room
  `@Index`/`@Transaction`/`@Upsert`, OkHttp logging condicional, Coil cache + crossfade, write-through cache) con `file:línea` y guía de medición.
  - `README.md` actualizado: la sección de arquitectura ahora mapea **coleccionistas en las cuatro capas** (endpoints, DTOs, modelos, repo, use cases,
  screen, components, DAO, binding de Hilt) y los **flujos POST del Sprint 2** (`createAlbum`, `addTrack`, `addComment`) con sus rutas, ViewModels, DTOs de
  escritura y nueva política write-through.

  ## Auditoría de patrones

  | Patrón | Estado |
  |---|---|
  | Service Adapter (Retrofit + DTOs) | ✓ Completo |
  | Repository (interface + impl + bindings Hilt) | ✓ Completo |
  | Room (entidades, DAOs, índices, transacciones, TypeConverters) | ✓ Completo |
  | Caching (network-first + fallback + **write-through**) | ✓ Completo (gap previo en escrituras corregido) |

  ## Test plan

  - [ ] `./gradlew clean assembleDebug` → BUILD SUCCESSFUL
  - [ ] `./gradlew :app:testDebugUnitTest` → 0 failures
  - [ ] `./gradlew connectedAndroidTest` (emulador API 33/34, animaciones desactivadas) → 0 failures
  - [ ] Smoke en emulador:
    - Listas de álbumes/artistas/coleccionistas → cargan, hacen scroll y pasan a detalle
    - Crear álbum (HU07) → vuelve a la lista y el nuevo álbum aparece sin esperar refetch
    - Agregar track (HU08) y comentario (HU09) → el detalle muestra el item nuevo
    - Modo avión + reabrir app → caché Room sirve listas y detalles previamente vistos
    - Portadas con `crossfade` al cargar; recargar la lista no vuelve a pegar a la red

  ## Notas

  - DB versión 3 → 4 con `fallbackToDestructiveMigration` (la caché es descartable; los datos viven en el backend).
  - Sin cambios en endpoints ni en el contrato del backend.
  - No hay cambios destructivos en API pública ni navegación.