### PR TITLE
Feature/hu12 agregar musicos banda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ CORRUTINAS_MICROOPTIMIZACIONES.md
 
 # Stitch files
 stitch_vinilos_app_screen_design_HU01/*
+stitch_vinilos_app_screen_design_HU09/*
+stitch_vinilos_app_screen_design_HU12/*
+superpowers/*
 
 # Freeline
 freeline.py

--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -6,9 +6,11 @@ Documento de referencia para las pruebas end-to-end de la app Vinilos.
 
 ## 1. Alcance
 
-Las pruebas E2E (`app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt`) atacan **`MainActivity` real** con **Hilt** arrancado, y consumen el **backend de Vinilos** levantado localmente vía docker-compose. No usan fakes ni mocks — validan la integración completa: UI → ViewModel → UseCase → Repositorio → Retrofit → backend → Room.
+Las pruebas E2E (`app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt`) atacan **`MainActivity` real** con **Hilt** arrancado y un módulo de test (`FakeRepositoryModule` con `@TestInstallIn(replaces = [RepositoryModule::class])`) que reemplaza los repositorios de producción por fakes en memoria. Validan la integración UI → ViewModel → UseCase → Repositorio fake y la navegación entre pantallas.
 
-Cobertura: features **Álbumes**, **Artistas** y **navegación entre tabs**.
+**No se requiere backend ni Docker.** El dataset es determinista (definido en los fakes), lo que elimina el flakiness de tests que dependían de la semilla del backend o de la red.
+
+Cobertura: features **Álbumes**, **Artistas**, **Bandas (HU012)** y **navegación entre tabs**.
 
 ---
 
@@ -17,11 +19,11 @@ Cobertura: features **Álbumes**, **Artistas** y **navegación entre tabs**.
 | Componente | Librería |
 |---|---|
 | Framework E2E | Jetpack Compose Test (`androidx.compose.ui:ui-test-junit4`) |
-| Instrumentación | `androidx.test:runner 1.6.2` |
-| DI en tests | `com.google.dagger:hilt-android-testing` |
+| Instrumentación | `androidx.test:runner 1.7.0` |
+| DI en tests | `com.google.dagger:hilt-android-testing 2.59.2` |
 | Runner custom | `com.misw4203.vinilos.HiltTestRunner` (arranca `HiltTestApplication`) |
+| Sustitución de repos | `FakeRepositoryModule` (en `app/src/androidTest/.../di/`) con `@TestInstallIn(replaces = [RepositoryModule::class])` |
 | Back del sistema | `androidx.test.espresso.Espresso.pressBack()` |
-| Backend | `backvynils-web-1` (docker) en `http://10.0.2.2:3000` |
 
 ---
 
@@ -29,15 +31,17 @@ Cobertura: features **Álbumes**, **Artistas** y **navegación entre tabs**.
 
 1. **Emulador Android API 33 o 34**.
    - API 35+ rompe Espresso 3.6.1 con `NoSuchMethodException: android.hardware.input.InputManager.getInstance`. Hasta que `espresso-core` stable lo soporte, usar Pixel 7/8 con Android 14 (API 34).
-2. **Backend docker corriendo**:
+2. **Animaciones desactivadas** en el emulador. Sin esto, Espresso/Compose nunca llegan a `idle` y todos los tests fallan con `IllegalStateException: No compose hierarchies found`:
    ```bash
-   docker compose up -d
-   # Verificar:
-   curl http://localhost:3000/albums
+   adb shell settings put global window_animation_scale 0
+   adb shell settings put global transition_animation_scale 0
+   adb shell settings put global animator_duration_scale 0
    ```
-   - `backvynils-db-1` (postgres:16) en puerto 5432.
-   - `backvynils-web-1` en puerto 3000.
-3. **Semilla del backend**: al menos 1 álbum y 1 artista. El set por defecto trae 4 álbumes (IDs 100–103) y 1 artista (ID 100).
+3. **Emulador despierto**. Una pantalla bloqueada / dormida (`mWakefulness=Asleep` en `dumpsys power`) impide que la `MainActivity` llegue a `setContent`:
+   ```bash
+   adb shell input keyevent KEYCODE_WAKEUP
+   adb shell svc power stayon true
+   ```
 
 ### Ejecución
 
@@ -72,68 +76,114 @@ testInstrumentationRunner = "com.misw4203.vinilos.HiltTestRunner"
 
 ### Deps añadidas en `libs.versions.toml`
 ```toml
-androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.6.2" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.7.0" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 ```
+
+### `FakeRepositoryModule` (sustituye al `RepositoryModule` real)
+
+```kotlin
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [RepositoryModule::class],
+)
+abstract class FakeRepositoryModule {
+    @Binds @Singleton abstract fun bindAlbumRepository(impl: FakeAlbumRepository): AlbumRepository
+    @Binds @Singleton abstract fun bindMusicianRepository(impl: FakeMusicianRepository): MusicianRepository
+    @Binds @Singleton abstract fun bindCollectorRepository(impl: FakeCollectorRepository): CollectorRepository
+    @Binds @Singleton abstract fun bindBandRepository(impl: FakeBandRepository): BandRepository
+}
+```
+
+Cada `FakeXRepository` es una implementación en memoria que devuelve datasets fijos, lo que hace los tests deterministas.
 
 ### `testTag`s agregados al código de producción
 | Composable | Tag |
 |---|---|
 | `AlbumListScreen` → `LazyColumn` | `albums_list` |
 | `AlbumCard` (wrapper en lista) | `album_card_{id}` |
-| `MusicianListScreen` → `LazyColumn` | `artists_list` |
+| `MusicianListContent` → `LazyColumn` | `artists_list` |
 | `MusicianCard` (wrapper en lista) | `musician_card_{id}` |
+| `BandListContent` → `LazyColumn` | `bands_list` |
+| `BandCard` (wrapper en lista) | `band_card_{id}` |
+| `CollectorListScreen` → `LazyColumn` | `collectors_list` |
+| `CollectorCard` (wrapper en lista) | `collector_card_{id}` |
 | `VinilosBottomNav` tabs | `bottom_nav_albums`, `bottom_nav_artists`, `bottom_nav_collectors` |
+| `ArtistsHubScreen` sub-tabs | `artists_tab_musicians`, `artists_tab_bands` |
 | `AlbumDetailScreen` root | `album_detail_root` |
 | `AlbumDetailScreen` back btn | `album_detail_back` |
 | `MusicianDetailScreen` body | `artist_detail_root` |
 | `MusicianDetailScreen` back btn | `artist_detail_back` |
+| `BandDetailScreen` root | `band_detail_root` |
+| `BandDetailScreen` back btn | `band_detail_back` |
+| `AddMusiciansToBandScreen` root | `add_musicians_screen_root` |
+| `AddMusiciansToBandScreen` back btn | `add_musicians_back` |
 | `PrizeItem` en detalle de artista | `prize_{id}` |
 
 ---
 
 ## 5. Escenarios cubiertos
 
-### Álbumes — lista y detalle
+La suite incluye **22 tests E2E** distribuidos en los módulos de Álbumes, Artistas, Coleccionistas, Bandas (HU012) y navegación. Cada test parte de datos deterministas inyectados por los fakes.
+
+### Álbumes — lista, detalle y creación
 | ID | Escenario | Cobertura |
 |---|---|---|
-| AL-01 | Dado el backend con álbumes, la pantalla principal muestra la lista. | ✅ E2E |
-| AL-05 | Dado que la lista está cargada, al tocar una card el usuario aterriza en el detalle. | ✅ E2E |
-| AD-01 | Dado un álbum abierto, se muestra su detalle (imagen, título, metadatos). | ✅ E2E |
-| AD-02 | Dado el detalle abierto, al tocar "back" vuelve a la lista. | ✅ E2E |
-| AD-05 | Dado un álbum con comentarios, el rating expone `contentDescription` accesible (TalkBack anuncia "N de 5 estrellas"). | ✅ E2E |
+| AL-01 | La pantalla principal muestra la lista de álbumes del catálogo. | ✅ E2E |
+| AL-05 | Al tocar una card el usuario aterriza en el detalle. | ✅ E2E |
+| AD-01 | Detalle abierto muestra imagen, título, metadatos. | ✅ E2E |
+| AD-02 | Botón back del top bar regresa a la lista. | ✅ E2E |
+| AD-05 | El rating de comentarios expone `contentDescription` accesible ("N de 5 estrellas"). | ✅ E2E |
+| AL-07 | El FAB abre el formulario de creación de álbum. | ✅ E2E |
+| AL-08 | El submit vacío en creación muestra errores de validación. | ✅ E2E |
 
 ### Artistas — lista y detalle
 | ID | Escenario | Cobertura |
 |---|---|---|
-| ML-01 | Dado el backend con artistas, al cambiar al tab "Artists" se muestra la lista. | ✅ E2E |
-| ML-04 | Dado el listado de artistas, al tocar una card se abre el detalle. | ✅ E2E |
-| MD-01 | Dado un artista abierto, se muestra su detalle. | ✅ E2E |
-| MD-04 | Dado el detalle abierto, al tocar "back" vuelve a la lista de artistas. | ✅ E2E |
+| ML-01 | Al cambiar al tab "Artists" se muestra la lista de músicos. | ✅ E2E |
+| ML-04 | Al tocar una card de músico se abre el detalle. | ✅ E2E |
+| MD-04 | Botón back regresa a la lista de artistas. | ✅ E2E |
+
+### Coleccionistas — lista y detalle
+| ID | Escenario | Cobertura |
+|---|---|---|
+| CL-01 | El tab "Collectors" muestra la lista. | ✅ E2E |
+| CL-02 | Las cards exponen sus testTags `collector_card_*`. | ✅ E2E |
+| CD-01 | El detalle muestra álbumes coleccionados y artistas favoritos. | ✅ E2E |
+| CD-02 | Botón back regresa a la lista (top bar y sistema). | ✅ E2E |
+| CD-05 | El rating de comentarios del coleccionista expone `contentDescription` accesible. | ✅ E2E |
+
+### Bandas (HU012) — flujo de agregar músicos
+| ID | Escenario | Cobertura |
+|---|---|---|
+| BD-01 | Desde el sub-tab "Bandas" se navega al detalle, se abre "Agregar músicos", se selecciona uno, se publica y aparece en integrantes. | ✅ E2E (`hu012_addMusicianToBand_flow`) |
 
 ### Navegación
 | ID | Escenario | Cobertura |
 |---|---|---|
-| NAV-01 | Dado estar en un tab, al tocar otro en la bottom nav cambia la pantalla y el título. | ✅ E2E |
-| NAV-03 | Dado estar en un detalle, el botón back del sistema regresa a la lista. | ✅ E2E |
+| NAV-01 | La bottom nav cambia entre tabs y el título refleja el cambio. | ✅ E2E |
+| NAV-03 | El back del sistema desde un detalle regresa a la lista. | ✅ E2E |
 
 ### Escenarios NO cubiertos por E2E (y dónde sí están)
 | ID | Escenario | Motivo de exclusión E2E | Cobertura alterna |
 |---|---|---|---|
-| AL-02, ML-02 | Empty state | No se puede forzar lista vacía en backend real | Unit tests de VM |
-| AL-03, AL-04, AL-06, AD-03, AD-04, ML-03 | Error state (red/servidor) + retry | No se puede inyectar `IOException` / HTTP 500 sin apagar docker mid-test | Unit tests de VM y repo |
-| AD-03, MD-05 | NotFound (404) | Requiere deep-link a ID inexistente; la nav no expone args de test | Unit tests de VM |
-| MD-02, MD-03 | AlertDialog de premios | La semilla actual no confirma performerPrizes en el artista base | Fácil de añadir si se garantiza dataset |
+| AL-02, ML-02 | Empty state | Los fakes inicializan con dataset poblado. Sería trivial añadir un flavor "empty" del fake si se requiere. | Unit tests de VM |
+| AL-03, AL-04, AL-06, AD-03, AD-04, ML-03 | Error state (red/servidor) + retry | Los fakes actuales no exponen un toggle de error; sería trivial añadir un setter para forzar `IOException` / `HttpException` en próximos escenarios. | Unit tests de VM y repo |
+| AD-03, MD-05 | NotFound (404) | Requiere deep-link a ID inexistente; la nav no expone args de test. | Unit tests de VM |
+| MD-02, MD-03 | AlertDialog de premios | El dataset fake del artista base no garantiza performerPrizes. Fácil de añadir. | Unit tests de VM |
 
 ---
 
 ## 6. Casos de prueba detallados
 
+> Esta sección documenta tests representativos. La suite completa (`VinilosE2ETest.kt`) tiene 22 tests y los no listados siguen el mismo patrón (`waitForTag` → `performClick` → assert). Para HU012 el test es `hu012_addMusicianToBand_flow`.
+
 ### 6.1 `albumList_rendersListFromBackend` — AL-01
 
 **Objetivo**: verificar que la pantalla inicial carga álbumes del backend.
 
-**Precondiciones**: backend up con ≥1 álbum.
+**Precondiciones**: el fake provee ≥1 álbum (true por defecto).
 
 **Pasos**:
 1. Esperar hasta que exista un nodo con `testTag("albums_list")` (timeout 10s).
@@ -147,7 +197,7 @@ hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testi
 
 **Objetivo**: flujo completo lista → detalle → regreso.
 
-**Precondiciones**: backend up con ≥1 álbum.
+**Precondiciones**: el fake provee ≥1 álbum (true por defecto).
 
 **Pasos**:
 1. Esperar a `albums_list`.
@@ -167,7 +217,7 @@ hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testi
 
 **Objetivo**: el tab "Artists" carga el listado de artistas.
 
-**Precondiciones**: backend up con ≥1 artista.
+**Precondiciones**: el fake provee ≥1 artista (true por defecto).
 
 **Pasos**:
 1. Click en `bottom_nav_artists`.
@@ -229,7 +279,7 @@ hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testi
 
 **Objetivo**: accesibilidad — los ratings de comentarios exponen `contentDescription` legible por TalkBack ("N de 5 estrellas").
 
-**Precondiciones**: el primer álbum del backend tiene ≥1 comentario.
+**Precondiciones**: el primer álbum del fake tiene ≥1 comentario.
 
 **Pasos**:
 1. Esperar a `albums_list`, scroll y click en el primer `album_card_*`.
@@ -270,15 +320,16 @@ Bloquean hasta que el nodo aparece en el semantic tree (timeout 10s). Necesarios
 
 1. **Compose ≠ Espresso clásico.** El brief original pedía `onView(withId(...))`, pero el proyecto es 100% Compose. La API correcta es `onNodeWithTag/Text/ContentDescription` + `SemanticsMatcher`. Espresso clásico no aplica salvo para `pressBack()`.
 2. **Espresso 3.6.1 + API 35+ = crash.** `InputManager.getInstance()` fue removido en API 34; Espresso aún lo reflexiona. Workaround: emulador API 33/34 hasta que salga una versión stable de `espresso-core` compatible.
-3. **IDs hardcodeados son frágiles.** Primer intento iteraba `album_card_1..50`, pero el backend siembra IDs 100–103. Solución: `SemanticsMatcher` con `startsWith`.
+3. **IDs hardcodeados son frágiles.** Aunque ahora los fakes definen IDs estables, mantenemos `SemanticsMatcher` con `startsWith` para acoplar menos los tests a los datos.
 4. **`assertIsDisplayed()` es estricto con viewport.** Para accesibilidad o para verificar que un nodo está en el tree, `assertExists()` es más correcto. TalkBack anuncia nodos aunque no estén en pantalla si el usuario hace scroll hacia ellos.
-5. **Network-first + cache puede enmascarar escenarios offline.** La primera vez que un test corre, la caché está vacía; tests subsecuentes pueden ver la caché aunque el backend esté abajo. Aceptable para esta suite (no testea offline), pero relevante si se añaden escenarios de error.
+5. **Animaciones y wake-lock matan los tests.** Sin animaciones desactivadas el idling resource nunca settlea (`No compose hierarchies found`); sin `stayon true` la `MainActivity` no llega a `setContent`. Ambos chequeos viven en la sección 3.
+6. **Fakes vs backend real.** El paso a `FakeRepositoryModule` eliminó el flakiness ligado a la semilla del backend y la latencia de red. El trade-off es que la integración Retrofit → backend → Room ya no se valida en CI; queda cubierta por unit tests del repositorio y, eventualmente, por un perfil opcional de tests con backend real.
 
 ---
 
 ## 9. Siguientes pasos (propuestos, no implementados)
 
-- **MockWebServer + `@UninstallModules(NetworkModule)`**: habilita escenarios de Error (AL-03/04, AD-03/04, ML-03) y NotFound (AD-03, MD-05) sin depender de apagar docker.
-- **Dataset seed determinista**: endpoint o script que garantice comentarios y prizes para estabilizar AD-05 y MD-02/03.
+- **Fakes con toggle de error**: añadir setters a los `FakeXRepository` para forzar `IOException` / `HttpException` y cubrir AL-03/04, AD-03/04, ML-03 sin tocar networking.
+- **Fakes "empty"**: variante o flag para devolver listas vacías y cubrir AL-02, ML-02 (Empty state).
 - **Screenshot testing (Paparazzi/Roborazzi)**: regressions visuales de cards, top bar, bottom nav. Costo: plugin adicional y PNGs en repo.
-- **CI**: ejecutar `connectedAndroidTest` en GitHub Actions con emulador API 34 y `docker compose up` previo.
+- **CI**: ejecutar `connectedAndroidTest` en GitHub Actions con emulador API 34. Sin docker (los fakes hacen la suite autosuficiente).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ app/src/main/java/com/misw4203/vinilos/
 │       ├── screens/
 │       │   ├── album/
 │       │   ├── artist/
+│       │   ├── band/
 │       │   └── collector/
 │       ├── components/  # Composables reutilizables
 │       └── theme/       # Material 3 theme
@@ -49,8 +50,8 @@ Responsable de obtener y persistir datos, ya sea desde la red o desde la base de
 | `data/local/dao/` | Interfaces DAO de Room con operaciones `@Upsert`, `@Query`, y transacciones (`replaceX` = clear + upsert). |
 | `data/local/database/` | `VinilosDatabase` — clase abstracta `RoomDatabase` que declara entidades y expone los DAOs. |
 | `data/local/entity/` | Entidades `@Entity` con mappers `toDomain()` / `fromDomain()`. |
-| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints de lectura (`GET /albums`, `GET /albums/{id}`, `GET /musicians`, `GET /musicians/{id}`, `GET /prizes/{id}`, `GET /collectors`, `GET /collectors/{id}`) y de escritura (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`). |
-| `data/remote/dto/` | DTOs que modelan la respuesta JSON (`AlbumDto`, `TrackDto`, `CommentDto`, `MusicianDetailDto`, `PrizeDetailDto`, `PerformerPrizeDto`, `CollectorDto`, `CollectorDetailDto`) y los bodies de escritura (`CreateAlbumRequestDto`, `CreateTrackRequest`, `CreateCommentRequest`). Campos nullables para tolerar datos incompletos del servidor. |
+| `data/remote/api/` | `VinilosApiService` — interfaz Retrofit con los endpoints de lectura (`GET /albums`, `GET /albums/{id}`, `GET /musicians`, `GET /musicians/{id}`, `GET /prizes/{id}`, `GET /collectors`, `GET /collectors/{id}`, `GET /bands`, `GET /bands/{id}`) y de escritura (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`, `POST /bands/{bandId}/musicians/{musicianId}`). |
+| `data/remote/dto/` | DTOs que modelan la respuesta JSON (`AlbumDto`, `TrackDto`, `CommentDto`, `MusicianDetailDto`, `PrizeDetailDto`, `PerformerPrizeDto`, `CollectorDto`, `CollectorDetailDto`, `BandDto`, `BandDetailDto`) y los bodies de escritura (`CreateAlbumRequestDto`, `CreateTrackRequest`, `CreateCommentRequest` con `CollectorRef`). Campos nullables para tolerar datos incompletos del servidor. |
 | `data/repository/` | Implementaciones de repositorio con estrategia **network-first + fallback a caché** para lecturas y POST directo a red (sin caché) para escrituras. |
 
 ### Estrategia de caché
@@ -61,10 +62,11 @@ Todos los repositorios siguen el mismo patrón para **lecturas**:
 2. Si la red falla con `IOException` (offline) → retorna la caché si existe; si no, re-lanza el error.
 3. Si falla con `HttpException` u otro → propaga (la UI clasifica 404, red, servidor, etc.).
 
-Para **escrituras** (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`) el repositorio aplica **write-through cache**:
+Para **escrituras** (`POST /albums`, `POST /albums/{id}/tracks`, `POST /albums/{id}/comments`, `POST /bands/{bandId}/musicians/{musicianId}`) el repositorio aplica **write-through cache best-effort**:
 
 - `createAlbum`: tras la respuesta exitosa hace `dao.upsert(AlbumEntity)` para insertar el nuevo álbum en la lista local.
 - `addTrack` / `addComment`: si existe un `AlbumDetailEntity` cacheado para ese `albumId`, se hace read-modify-write apilando el nuevo track/comentario y `upsertDetail` lo persiste; si el detalle aún no está en caché, se omite la escritura local (el próximo `getAlbumById` la repoblará).
+- `addMusicianToBand`: enriquece el detalle de banda en caché con el nuevo integrante. La enriquecimiento va envuelto en `try/catch` (re-lanzando `CancellationException`) para que un fallo del cache no convierta un POST exitoso en error visible.
 
 Adicionalmente, la pantalla origen invalida su `UiState` vía `retry()` o un flag en `SavedStateHandle`. Esto asegura coherencia inmediata aunque se produzca una desconexión justo después del POST. Las excepciones se propagan al ViewModel sin envolverlas, igual que en las lecturas.
 
@@ -76,9 +78,9 @@ Es el núcleo de la aplicación. No depende de ninguna otra capa y contiene la l
 
 | Carpeta | Contenido |
 |---|---|
-| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `MusicianPrize`, `Track`, `Performer`, `Comment`, `CollectorSummary`, `CollectorDetail`, `CollectorAlbum`, `CollectorComment`, `CreateAlbumInput`). Sin dependencias de Android. |
-| `domain/repository/` | Interfaces de repositorio (`AlbumRepository` con `getAlbums`, `getAlbumById`, `createAlbum`, `addTrack`, `addComment`; `MusicianRepository`; `CollectorRepository`). |
-| `domain/usecase/` | Casos de uso de lectura (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`, `GetCollectorsUseCase`, `GetCollectorDetailUseCase`) y de escritura (`CreateAlbumUseCase`, `AddTrackUseCase`, `AddCommentUseCase`). |
+| `domain/model/` | Modelos de dominio (`Album`, `AlbumDetail`, `Musician`, `MusicianSummary`, `MusicianPrize`, `Track`, `Performer`, `Comment` (con `commenter: CollectorSummary?`), `CollectorSummary`, `CollectorDetail`, `CollectorAlbum`, `CollectorComment`, `Band`, `BandSummary`, `CreateAlbumInput`). Sin dependencias de Android. |
+| `domain/repository/` | Interfaces de repositorio (`AlbumRepository` con `getAlbums`, `getAlbumById`, `createAlbum`, `addTrack`, `addComment`; `MusicianRepository`; `CollectorRepository`; `BandRepository` con `getBands`, `getBandDetail`, `addMusicianToBand`). |
+| `domain/usecase/` | Casos de uso de lectura (`GetAlbumsUseCase`, `GetAlbumDetailUseCase`, `GetMusiciansUseCase`, `GetMusicianDetailUseCase`, `GetCollectorsUseCase`, `GetCollectorDetailUseCase`, `GetBandsUseCase`, `GetBandDetailUseCase`) y de escritura (`CreateAlbumUseCase`, `AddTrackUseCase`, `AddCommentUseCase`, `AddMusicianToBandUseCase`). |
 
 ---
 
@@ -88,10 +90,10 @@ Contiene todo lo relacionado con la interfaz de usuario y el estado de la pantal
 
 | Carpeta | Contenido |
 |---|---|
-| `presentation/navigation/` | `VinilosNavHost` + `Destinations` (rutas: `album_list`, `album_detail/{albumId}`, `create_album`, `album/{albumId}/track/add`, `album/{albumId}/comment/add/{collectorId}`, `artists`, `artist/{id}`, `collectors`, `collector/{collectorId}`). |
-| `presentation/viewmodel/` | ViewModels con `@HiltViewModel`. Para listas/detalle exponen `StateFlow<UiState>` (`Loading / Success / Empty\|NotFound / Error(isNetworkError)`) y clasifican excepciones (`IOException` → red, `HttpException` 404 → NotFound, otros → servidor). Para formularios POST (`CreateAlbumViewModel`, `AddTrackViewModel`, `AddCommentViewModel`) separan el form state del submit state (`Idle / Loading / Success / Error`). Todos re-lanzan `CancellationException` para preservar structured concurrency. |
-| `presentation/ui/screens/` | Composables por entidad: `album/` (`AlbumListScreen`, `AlbumDetailScreen`, `CreateAlbumScreen`, `AddTrackScreen`, `AddCommentScreen`), `artist/` (`MusicianListScreen`, `MusicianDetailScreen`), `collector/` (`CollectorListScreen`, `CollectorDetailScreen`). |
-| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `CollectorCard`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`, `SearchBarStatic`, `ListCounter`, `RatingBar`. |
+| `presentation/navigation/` | `VinilosNavHost` + `Destinations` (rutas: `album_list`, `album_detail/{albumId}`, `create_album`, `album/{albumId}/track/add`, `album/{albumId}/comment/add/{collectorId}`, `artists` (hub con sub-tabs Músicos / Bandas), `artist/{id}`, `band/{bandId}`, `band/{bandId}/musicians/add`, `collectors`, `collector/{collectorId}`). |
+| `presentation/viewmodel/` | ViewModels con `@HiltViewModel`. Para listas/detalle exponen `StateFlow<UiState>` (`Loading / Success / Empty\|NotFound / Error(isNetworkError)`) y clasifican excepciones (`IOException` → red, `HttpException` 404 → NotFound, otros → servidor). Para formularios POST (`CreateAlbumViewModel`, `AddTrackViewModel`, `AddCommentViewModel`, `AddMusiciansToBandViewModel`) separan el form state del submit state (`Idle / Loading / Success / Error`) y emiten eventos one-shot (`MutableSharedFlow<Event>`) para snackbars de éxito/fallo, de modo que la rotación de pantalla no los re-dispare. Todos re-lanzan `CancellationException` para preservar structured concurrency. |
+| `presentation/ui/screens/` | Composables por entidad: `album/` (`AlbumListScreen`, `AlbumDetailScreen`, `CreateAlbumScreen`, `AddTrackScreen`, `AddCommentScreen`), `artist/` (`ArtistsHubScreen` con `MusicianListContent` + `BandListContent`, `MusicianDetailScreen`), `band/` (`BandDetailScreen`, `AddMusiciansToBandScreen`), `collector/` (`CollectorListScreen`, `CollectorDetailScreen`). |
+| `presentation/ui/components/` | `AlbumCard`, `MusicianCard`, `BandCard`, `CollectorCard`, `MusicianRow`, `EmptyMembersState`, `PerformerHeader`, `LoadingState`, `EmptyState`, `ErrorState`, `VinilosTopBar`, `VinilosBottomNav`, `SearchBarStatic`, `ListCounter`, `RatingBar`. |
 | `presentation/ui/theme/` | Material 3: `Color.kt`, `Theme.kt`, `Type.kt`. |
 
 ---
@@ -103,8 +105,8 @@ Módulos de Hilt instalados en `SingletonComponent`.
 | Archivo | Contenido |
 |---|---|
 | `NetworkModule` | Provee `OkHttpClient` (con `HttpLoggingInterceptor` solo en debug), `Retrofit` y `VinilosApiService`. |
-| `DatabaseModule` | Provee `VinilosDatabase` (con `fallbackToDestructiveMigration` — la caché es descartable) y los DAOs (`AlbumDao`, `MusicianDao`, `CollectorDao`). |
-| `RepositoryModule` | `@Binds` de las interfaces de dominio a sus implementaciones: `AlbumRepository → AlbumRepositoryImpl`, `MusicianRepository → MusicianRepositoryImpl`, `CollectorRepository → CollectorRepositoryImpl`. |
+| `DatabaseModule` | Provee `VinilosDatabase` v5 (con `fallbackToDestructiveMigration` — la caché es descartable) y los DAOs (`AlbumDao`, `MusicianDao`, `CollectorDao`, `BandDao`). |
+| `RepositoryModule` | `@Binds` de las interfaces de dominio a sus implementaciones: `AlbumRepository → AlbumRepositoryImpl`, `MusicianRepository → MusicianRepositoryImpl`, `CollectorRepository → CollectorRepositoryImpl`, `BandRepository → BandRepositoryImpl`. |
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.misw4203.vinilos"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.misw4203.vinilos"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "com.misw4203.vinilos.HiltTestRunner"

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeBandRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeBandRepository.kt
@@ -1,0 +1,28 @@
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class FakeBandRepository @Inject constructor() : BandRepository {
+
+    override suspend fun getBands(): List<BandSummary> = listOf(
+        BandSummary(1, "Queen", ""),
+        BandSummary(2, "The Beatles", ""),
+    )
+
+    override suspend fun getBandDetail(id: Int): Band = Band(
+        id = id,
+        name = "Queen",
+        image = "",
+        description = "Banda de rock británica formada en Londres en 1970.",
+        creationDate = "1970-01-01T00:00:00.000Z",
+        members = emptyList(),
+        albums = emptyList(),
+    )
+
+    override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+        // no-op
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.misw4203.vinilos.di
 
 import com.misw4203.vinilos.domain.repository.AlbumRepository
+import com.misw4203.vinilos.domain.repository.BandRepository
 import com.misw4203.vinilos.domain.repository.CollectorRepository
 import com.misw4203.vinilos.domain.repository.MusicianRepository
 import dagger.Binds
@@ -27,4 +28,8 @@ abstract class FakeRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindCollectorRepository(impl: FakeCollectorRepository): CollectorRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindBandRepository(impl: FakeBandRepository): BandRepository
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -359,6 +359,69 @@ class VinilosE2ETest {
             .assertExists()
     }
 
+    // -- HU012: Agregar músicos a banda --------------------------------------
+
+    /**
+     * HU012: flujo completo de agregar un músico a una banda.
+     * Bottom-nav → sub-tab Bandas → detalle de banda → CTA agregar
+     * (empty-state o regular) → "+" en disponibles → verificación de que
+     * el músico aparece en "Integrantes actuales".
+     */
+    @Test
+    fun hu012_addMusicianToBand_flow() {
+        // 1. Bottom-nav → tab Artistas
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+
+        // 2. Sub-tab "Bandas"
+        waitForTag("artists_tab_bands")
+        composeRule.onNodeWithTag("artists_tab_bands").performClick()
+
+        // 3. Tap primera banda disponible (band_card_<id>)
+        val bandCard = tagStartsWith("band_card_")
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(bandCard).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onAllNodes(bandCard)[0].performClick()
+
+        // 4. En el detalle de la banda, click en CTA empty-state o regular
+        waitForTag("band_detail_root")
+        val emptyCta = composeRule.activity.getString(R.string.add_first_member_cta)
+        val regularCta = composeRule.activity.getString(R.string.add_musicians_cta)
+        // Empty-state primero; fallback al botón regular si la banda ya tiene miembros.
+        val emptyNodes = composeRule.onAllNodesWithText(emptyCta).fetchSemanticsNodes()
+        if (emptyNodes.isNotEmpty()) {
+            composeRule.onNodeWithText(emptyCta).performClick()
+        } else {
+            composeRule.onNodeWithText(regularCta).performClick()
+        }
+
+        // 5. En la pantalla de agregar músicos, esperamos a que carguen los disponibles
+        // y hacemos click en el "+" del primer músico disponible.
+        waitForTag("add_musicians_screen_root")
+        val availableMusician = tagStartsWith("available_musician_")
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(availableMusician).fetchSemanticsNodes().isNotEmpty()
+        }
+        // El "+" tiene contentDescription = "Agregar {nombre} a la banda" (R.string.cd_add_musician_to_band).
+        val addButton = SemanticsMatcher("ContentDescription starts with 'Agregar ' and ends with ' a la banda'") { node ->
+            val cd = node.config.getOrNull(SemanticsProperties.ContentDescription) ?: return@SemanticsMatcher false
+            cd.any { it.startsWith("Agregar ") && it.endsWith(" a la banda") }
+        }
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(addButton).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onAllNodes(addButton)[0].performClick()
+
+        // 6. Verificar que el músico ahora aparece en "Integrantes actuales".
+        // El ViewModel hace optimistic update local, por lo que aparece en current_member_<id>
+        // aunque el repository fake no persista el cambio.
+        val currentMember = tagStartsWith("current_member_")
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(currentMember).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onAllNodes(currentMember)[0].assertExists()
+    }
+
     // -- Helpers -------------------------------------------------------------
 
     private fun waitForTag(tag: String) {

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/BandCardTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/BandCardTest.kt
@@ -1,0 +1,45 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.domain.model.BandSummary
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class BandCardTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val sample = BandSummary(id = 1, name = "Queen", image = "")
+
+    @Test
+    fun rendersBandName() {
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = {}) }
+        }
+        composeTestRule.onNodeWithText("Queen").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersBandBadge() {
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = {}) }
+        }
+        composeTestRule.onNodeWithText("BANDA").assertIsDisplayed()
+    }
+
+    @Test
+    fun clickTriggersCallback() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = { clicked = true }) }
+        }
+        composeTestRule.onNodeWithText("Queen").performClick()
+        assertTrue(clicked)
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersStateTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersStateTest.kt
@@ -1,0 +1,38 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.R
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class EmptyMembersStateTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun rendersEmptyTitleAndBody() {
+        composeTestRule.setContent {
+            MaterialTheme { EmptyMembersState(onAddFirst = {}) }
+        }
+        val title = composeTestRule.activity.getString(R.string.band_members_empty_title)
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun clickCtaInvokesCallback() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme { EmptyMembersState(onAddFirst = { clicked = true }) }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.onNodeWithText(cta).performClick()
+        assertTrue(clicked)
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/MusicianRowTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/MusicianRowTest.kt
@@ -1,0 +1,57 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class MusicianRowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val sample = MusicianSummary(10, "Freddie Mercury", "", "1946-09-05")
+
+    @Test
+    fun rendersMusicianName() {
+        composeTestRule.setContent {
+            MaterialTheme { MusicianRow(musician = sample, isAdding = false, onAdd = {}) }
+        }
+        composeTestRule.onNodeWithText("Freddie Mercury").assertIsDisplayed()
+    }
+
+    @Test
+    fun clickPlusInvokesOnAddWithMusicianId() {
+        var addedId: Int? = null
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianRow(musician = sample, isAdding = false, onAdd = { addedId = it })
+            }
+        }
+        val cd = composeTestRule.activity.getString(R.string.cd_add_musician_to_band, "Freddie Mercury")
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        assertEquals(10, addedId)
+    }
+
+    @Test
+    fun whenAddingShowsLoadingIndicatorAndDisablesButton() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianRow(musician = sample, isAdding = true, onAdd = { clicked = true })
+            }
+        }
+        val cd = composeTestRule.activity.getString(R.string.cd_adding_musician)
+        composeTestRule.onNodeWithContentDescription(cd).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        assertEquals(false, clicked)
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
@@ -5,8 +5,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.SavedStateHandle
@@ -19,6 +21,7 @@ import com.misw4203.vinilos.domain.repository.MusicianRepository
 import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
 import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
 import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
 import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -53,7 +56,7 @@ class AddMusiciansToBandScreenTest {
             getMusicians = GetMusiciansUseCase(FakeMusicianRepo(catalog)),
             getBandDetail = GetBandDetailUseCase(bandRepo),
             addMusicianToBand = AddMusicianToBandUseCase(bandRepo),
-            savedStateHandle = SavedStateHandle(mapOf("bandId" to bandId)),
+            savedStateHandle = SavedStateHandle(mapOf(Destinations.AddMusiciansBandArg to bandId)),
         )
     }
 
@@ -138,5 +141,35 @@ class AddMusiciansToBandScreenTest {
                 .fetchSemanticsNodes().isEmpty()
         }
         composeTestRule.onNodeWithTag("current_member_10").assertIsDisplayed()
+    }
+
+    @Test
+    fun loadErrorShowsErrorStateWithRetry() {
+        val musicianRepo = FakeMusicianRepo(emptyList())
+        val bandRepo = object : BandRepository {
+            override suspend fun getBands(): List<BandSummary> = error("not used")
+            override suspend fun getBandDetail(id: Int): Band = throw java.io.IOException("offline")
+            override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = Unit
+        }
+        val vm = AddMusiciansToBandViewModel(
+            getMusicians = GetMusiciansUseCase(musicianRepo),
+            getBandDetail = GetBandDetailUseCase(bandRepo),
+            addMusicianToBand = AddMusicianToBandUseCase(bandRepo),
+            savedStateHandle = SavedStateHandle(mapOf(Destinations.AddMusiciansBandArg to 1)),
+        )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithText(
+                composeTestRule.activity.getString(R.string.action_retry)
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.action_retry)
+        ).assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
@@ -1,0 +1,142 @@
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.SavedStateHandle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
+import org.junit.Rule
+import org.junit.Test
+
+class AddMusiciansToBandScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakeMusicianRepo(val list: List<MusicianSummary>) : MusicianRepository {
+        override suspend fun getMusicians() = list
+        override suspend fun getMusicianDetail(id: Int) = error("not used")
+    }
+
+    private class FakeBandRepo(val band: Band) : BandRepository {
+        var added = mutableListOf<Pair<Int, Int>>()
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = band
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+            added += bandId to musicianId
+        }
+    }
+
+    private fun buildVm(
+        catalog: List<MusicianSummary>,
+        currentMembers: List<MusicianSummary>,
+        bandId: Int = 1,
+    ): AddMusiciansToBandViewModel {
+        val band = Band(bandId, "Queen", "", "", "", currentMembers, emptyList())
+        val bandRepo = FakeBandRepo(band)
+        return AddMusiciansToBandViewModel(
+            getMusicians = GetMusiciansUseCase(FakeMusicianRepo(catalog)),
+            getBandDetail = GetBandDetailUseCase(bandRepo),
+            addMusicianToBand = AddMusicianToBandUseCase(bandRepo),
+            savedStateHandle = SavedStateHandle(mapOf("bandId" to bandId)),
+        )
+    }
+
+    @Test
+    fun rendersAvailableExcludingExistingMembers() {
+        val catalog = listOf(
+            MusicianSummary(10, "Freddie Mercury", "", ""),
+            MusicianSummary(11, "Brian May", "", ""),
+        )
+        val members = listOf(MusicianSummary(10, "Freddie Mercury", "", ""))
+        val vm = buildVm(catalog, members)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_11")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("available_musician_11").assertIsDisplayed()
+        // Freddie is already a member, so should NOT be in available list
+        assert(
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isEmpty()
+        )
+    }
+
+    @Test
+    fun searchFiltersList() {
+        val catalog = listOf(
+            MusicianSummary(10, "Freddie Mercury", "", ""),
+            MusicianSummary(11, "Brian May", "", ""),
+        )
+        val vm = buildVm(catalog, emptyList())
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("add_musicians_search").performTextInput("brian")
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onNodeWithTag("available_musician_11").assertIsDisplayed()
+    }
+
+    @Test
+    fun addingMusicianRemovesFromAvailableList() {
+        val catalog = listOf(MusicianSummary(10, "Freddie Mercury", "", ""))
+        val vm = buildVm(catalog, emptyList())
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        val cd = composeTestRule.activity.getString(
+            R.string.cd_add_musician_to_band, "Freddie Mercury"
+        )
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onNodeWithTag("current_member_10").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -101,6 +102,28 @@ class BandDetailScreenTest {
         }
         composeTestRule.onNodeWithText(cta).performClick()
         assertEquals(true, clicked)
+    }
+
+    @Test
+    fun errorStateShowsRetry() {
+        val vm = buildVm(FakeRepo(Result.failure(java.io.IOException("offline"))))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodesWithText(
+                composeTestRule.activity.getString(com.misw4203.vinilos.R.string.action_retry)
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(com.misw4203.vinilos.R.string.action_retry)
+        ).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreenTest.kt
@@ -1,0 +1,125 @@
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModel
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+class BandDetailScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakeRepo(val result: Result<Band>) : BandRepository {
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = result.getOrThrow()
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    private fun buildVm(repo: BandRepository) = BandDetailViewModel(GetBandDetailUseCase(repo))
+
+    @Test
+    fun successWithEmptyMembersShowsEmptyMembersStateCta() {
+        val band = Band(1, "Queen", "", "", "", emptyList(), emptyList())
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(hasText(cta)).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(cta).assertIsDisplayed()
+    }
+
+    @Test
+    fun successWithMembersShowsListAndAddButton() {
+        val band = Band(
+            1, "Queen", "", "", "",
+            members = listOf(MusicianSummary(10, "Freddie", "", "")),
+            albums = emptyList(),
+        )
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(hasText("Freddie")).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Freddie").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("band_detail_add_musicians").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyCtaInvokesOnAddMusicians() {
+        var clicked = false
+        val band = Band(1, "Queen", "", "", "", emptyList(), emptyList())
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {},
+                    onAddMusicians = { clicked = true },
+                    viewModel = vm,
+                )
+            }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(hasText(cta)).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(cta).performClick()
+        assertEquals(true, clicked)
+    }
+
+    @Test
+    fun notFoundShowsMessage() {
+        val http404 = HttpException(Response.error<Any>(404, "".toResponseBody("text/plain".toMediaType())))
+        val vm = buildVm(FakeRepo(Result.failure(http404)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        val title = composeTestRule.activity.getString(R.string.band_not_found_title)
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(hasText(title)).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt
@@ -8,6 +8,7 @@ import com.misw4203.vinilos.domain.model.CollectorAlbum
 import com.misw4203.vinilos.domain.model.CollectorComment
 import com.misw4203.vinilos.domain.model.Comment
 import com.misw4203.vinilos.domain.model.MusicianPrize
+import com.misw4203.vinilos.domain.model.MusicianSummary
 import com.misw4203.vinilos.domain.model.Performer
 import com.misw4203.vinilos.domain.model.Track
 
@@ -62,4 +63,11 @@ class Converters {
     @TypeConverter
     fun jsonToCollectorComments(value: String): List<CollectorComment> =
         gson.fromJson(value, object : TypeToken<List<CollectorComment>>() {}.type)
+
+    @TypeConverter
+    fun musicianSummariesToJson(value: List<MusicianSummary>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToMusicianSummaries(value: String): List<MusicianSummary> =
+        gson.fromJson(value, object : TypeToken<List<MusicianSummary>>() {}.type)
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/local/dao/BandDao.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/dao/BandDao.kt
@@ -1,0 +1,33 @@
+package com.misw4203.vinilos.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+
+@Dao
+interface BandDao {
+
+    @Query("SELECT * FROM bands ORDER BY name ASC")
+    suspend fun getAll(): List<BandListEntity>
+
+    @Upsert
+    suspend fun upsertAll(bands: List<BandListEntity>)
+
+    @Query("DELETE FROM bands")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun replaceBands(bands: List<BandListEntity>) {
+        clear()
+        upsertAll(bands)
+    }
+
+    @Query("SELECT * FROM band_details WHERE id = :id")
+    suspend fun getDetailById(id: Int): BandDetailEntity?
+
+    @Upsert
+    suspend fun upsertDetail(detail: BandDetailEntity)
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt
@@ -5,10 +5,13 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.misw4203.vinilos.data.local.converter.Converters
 import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.dao.BandDao
 import com.misw4203.vinilos.data.local.dao.CollectorDao
 import com.misw4203.vinilos.data.local.dao.MusicianDao
 import com.misw4203.vinilos.data.local.entity.AlbumDetailEntity
 import com.misw4203.vinilos.data.local.entity.AlbumEntity
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
 import com.misw4203.vinilos.data.local.entity.CollectorDetailEntity
 import com.misw4203.vinilos.data.local.entity.CollectorEntity
 import com.misw4203.vinilos.data.local.entity.MusicianDetailEntity
@@ -22,8 +25,10 @@ import com.misw4203.vinilos.data.local.entity.MusicianListEntity
         MusicianDetailEntity::class,
         CollectorEntity::class,
         CollectorDetailEntity::class,
+        BandListEntity::class,
+        BandDetailEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = false,
 )
 @TypeConverters(Converters::class)
@@ -31,4 +36,5 @@ abstract class VinilosDatabase : RoomDatabase() {
     abstract fun albumDao(): AlbumDao
     abstract fun musicianDao(): MusicianDao
     abstract fun collectorDao(): CollectorDao
+    abstract fun bandDao(): BandDao
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/BandDetailEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/BandDetailEntity.kt
@@ -1,0 +1,40 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+@Entity(tableName = "band_details")
+data class BandDetailEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val creationDate: String,
+    val members: List<MusicianSummary>,
+    val albums: List<Album>,
+) {
+    fun toDomain() = Band(
+        id = id,
+        name = name,
+        image = image,
+        description = description,
+        creationDate = creationDate,
+        members = members,
+        albums = albums,
+    )
+
+    companion object {
+        fun fromDomain(band: Band) = BandDetailEntity(
+            id = band.id,
+            name = band.name,
+            image = band.image,
+            description = band.description,
+            creationDate = band.creationDate,
+            members = band.members,
+            albums = band.albums,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/local/entity/BandListEntity.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/local/entity/BandListEntity.kt
@@ -1,0 +1,30 @@
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.BandSummary
+
+@Entity(
+    tableName = "bands",
+    indices = [Index(value = ["name"])],
+)
+data class BandListEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+) {
+    fun toDomain() = BandSummary(
+        id = id,
+        name = name,
+        image = image,
+    )
+
+    companion object {
+        fun fromDomain(summary: BandSummary) = BandListEntity(
+            id = summary.id,
+            name = summary.name,
+            image = summary.image,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
@@ -1,6 +1,8 @@
 package com.misw4203.vinilos.data.remote.api
 
 import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
 import com.misw4203.vinilos.data.remote.dto.CollectorDetailDto
 import com.misw4203.vinilos.data.remote.dto.CollectorDto
 import com.misw4203.vinilos.data.remote.dto.CommentDto
@@ -10,6 +12,7 @@ import com.misw4203.vinilos.data.remote.dto.CreateTrackRequest
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
 import com.misw4203.vinilos.data.remote.dto.PrizeDetailDto
 import com.misw4203.vinilos.data.remote.dto.TrackDto
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -52,4 +55,19 @@ interface VinilosApiService {
         @Path("id") albumId: Long,
         @Body request: CreateCommentRequest,
     ): CommentDto
+
+    @GET("bands")
+    suspend fun getBands(): List<BandDto>
+
+    @GET("bands/{id}")
+    suspend fun getBandDetail(@Path("id") id: Int): BandDetailDto
+
+    @GET("bands/{id}/musicians")
+    suspend fun getBandMembers(@Path("id") id: Int): List<MusicianDetailDto>
+
+    @POST("bands/{bandId}/musicians/{musicianId}")
+    suspend fun addMusicianToBand(
+        @Path("bandId") bandId: Int,
+        @Path("musicianId") musicianId: Int,
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
@@ -12,7 +12,6 @@ import com.misw4203.vinilos.data.remote.dto.CreateTrackRequest
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
 import com.misw4203.vinilos.data.remote.dto.PrizeDetailDto
 import com.misw4203.vinilos.data.remote.dto.TrackDto
-import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -62,12 +61,9 @@ interface VinilosApiService {
     @GET("bands/{id}")
     suspend fun getBandDetail(@Path("id") id: Int): BandDetailDto
 
-    @GET("bands/{id}/musicians")
-    suspend fun getBandMembers(@Path("id") id: Int): List<MusicianDetailDto>
-
     @POST("bands/{bandId}/musicians/{musicianId}")
     suspend fun addMusicianToBand(
         @Path("bandId") bandId: Int,
         @Path("musicianId") musicianId: Int,
-    ): Response<Unit>
+    )
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDetailDto.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDetailDto.kt
@@ -1,0 +1,13 @@
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class BandDetailDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("creationDate") val creationDate: String?,
+    @SerializedName("musicians") val musicians: List<MusicianDetailDto>?,
+    @SerializedName("albums") val albums: List<AlbumDto>?,
+)

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDto.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDto.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class BandDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("creationDate") val creationDate: String?,
+)

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/AlbumRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.misw4203.vinilos.data.remote.dto.CreateCommentRequest
 import com.misw4203.vinilos.data.remote.dto.CreateTrackRequest
 import com.misw4203.vinilos.domain.model.Album
 import com.misw4203.vinilos.domain.model.AlbumDetail
+import com.misw4203.vinilos.domain.model.CollectorSummary
 import com.misw4203.vinilos.domain.model.Comment
 import com.misw4203.vinilos.domain.model.CreateAlbumInput
 import com.misw4203.vinilos.domain.model.Performer
@@ -83,6 +84,7 @@ class AlbumRepositoryImpl @Inject constructor(
             id = response.id,
             description = response.description.orEmpty(),
             rating = response.rating ?: rating,
+            commenter = response.collector?.toSummary(),
         )
         // Write-through cache: ver nota en addTrack.
         dao.getDetailById(albumId)?.let { cached ->
@@ -147,7 +149,11 @@ class AlbumRepositoryImpl @Inject constructor(
                 id = c.id,
                 description = c.description.orEmpty(),
                 rating = c.rating ?: 0,
+                commenter = c.collector?.toSummary(),
             )
         }.orEmpty(),
     )
+
+    private fun com.misw4203.vinilos.data.remote.dto.CollectorDto.toSummary(): CollectorSummary =
+        CollectorSummary(id = id, name = name, telephone = telephone, email = email)
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.misw4203.vinilos.domain.model.Band
 import com.misw4203.vinilos.domain.model.BandSummary
 import com.misw4203.vinilos.domain.model.MusicianSummary
 import com.misw4203.vinilos.domain.repository.BandRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -46,18 +47,26 @@ class BandRepositoryImpl @Inject constructor(
 
     override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = withContext(Dispatchers.IO) {
         api.addMusicianToBand(bandId, musicianId)
-        // Write-through: si el detalle esta cacheado, agregamos el nuevo miembro.
-        val cached = dao.getDetailById(bandId)
-        if (cached != null) {
-            val musicianDto = api.getMusicianDetail(musicianId)
-            val newMember = MusicianSummary(
-                id = musicianDto.id,
-                name = musicianDto.name,
-                image = musicianDto.image,
-                birthDate = musicianDto.birthDate,
-            )
-            val updated = cached.copy(members = cached.members + newMember)
-            dao.upsertDetail(updated)
+        // Write-through best-effort: si el detalle esta cacheado, intentamos
+        // refrescar members. Un fallo aqui no debe propagarse: la cache se
+        // reconciliara con el servidor en el proximo getBandDetail.
+        try {
+            val cached = dao.getDetailById(bandId)
+            if (cached != null) {
+                val musicianDto = api.getMusicianDetail(musicianId)
+                val newMember = MusicianSummary(
+                    id = musicianDto.id,
+                    name = musicianDto.name,
+                    image = musicianDto.image,
+                    birthDate = musicianDto.birthDate,
+                )
+                val updated = cached.copy(members = cached.members + newMember)
+                dao.upsertDetail(updated)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // best-effort
         }
         Unit
     }
@@ -75,7 +84,12 @@ class BandRepositoryImpl @Inject constructor(
         description = description.orEmpty(),
         creationDate = creationDate.orEmpty(),
         members = musicians.orEmpty().map {
-            MusicianSummary(it.id, it.name, it.image, it.birthDate)
+            MusicianSummary(
+                id = it.id,
+                name = it.name,
+                image = it.image,
+                birthDate = it.birthDate,
+            )
         },
         albums = albums.orEmpty().map { it.toDomain() },
     )

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt
@@ -1,0 +1,91 @@
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.BandDao
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import javax.inject.Inject
+
+class BandRepositoryImpl @Inject constructor(
+    private val api: VinilosApiService,
+    private val dao: BandDao,
+) : BandRepository {
+
+    override suspend fun getBands(): List<BandSummary> = withContext(Dispatchers.IO) {
+        try {
+            val summaries = api.getBands().map { it.toSummary() }
+            dao.replaceBands(summaries.map { BandListEntity.fromDomain(it) })
+            summaries
+        } catch (e: IOException) {
+            val cached = dao.getAll()
+            if (cached.isNotEmpty()) cached.map { it.toDomain() } else throw e
+        }
+    }
+
+    override suspend fun getBandDetail(id: Int): Band = withContext(Dispatchers.IO) {
+        try {
+            val dto = api.getBandDetail(id)
+            val band = dto.toDomain()
+            dao.upsertDetail(BandDetailEntity.fromDomain(band))
+            band
+        } catch (e: IOException) {
+            dao.getDetailById(id)?.toDomain() ?: throw e
+        }
+    }
+
+    override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = withContext(Dispatchers.IO) {
+        api.addMusicianToBand(bandId, musicianId)
+        // Write-through: si el detalle esta cacheado, agregamos el nuevo miembro.
+        val cached = dao.getDetailById(bandId)
+        if (cached != null) {
+            val musicianDto = api.getMusicianDetail(musicianId)
+            val newMember = MusicianSummary(
+                id = musicianDto.id,
+                name = musicianDto.name,
+                image = musicianDto.image,
+                birthDate = musicianDto.birthDate,
+            )
+            val updated = cached.copy(members = cached.members + newMember)
+            dao.upsertDetail(updated)
+        }
+        Unit
+    }
+
+    private fun BandDto.toSummary() = BandSummary(
+        id = id,
+        name = name.orEmpty(),
+        image = image.orEmpty(),
+    )
+
+    private fun BandDetailDto.toDomain() = Band(
+        id = id,
+        name = name.orEmpty(),
+        image = image.orEmpty(),
+        description = description.orEmpty(),
+        creationDate = creationDate.orEmpty(),
+        members = musicians.orEmpty().map {
+            MusicianSummary(it.id, it.name, it.image, it.birthDate)
+        },
+        albums = albums.orEmpty().map { it.toDomain() },
+    )
+
+    private fun AlbumDto.toDomain() = Album(
+        id = id,
+        name = name.orEmpty(),
+        coverUrl = cover.orEmpty(),
+        artistName = performers?.firstOrNull()?.name.orEmpty(),
+        releaseYear = releaseDate?.take(4).orEmpty(),
+        genre = genre.orEmpty(),
+    )
+}

--- a/app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt
+++ b/app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.misw4203.vinilos.di
 import android.content.Context
 import androidx.room.Room
 import com.misw4203.vinilos.data.local.dao.AlbumDao
+import com.misw4203.vinilos.data.local.dao.BandDao
 import com.misw4203.vinilos.data.local.dao.CollectorDao
 import com.misw4203.vinilos.data.local.dao.MusicianDao
 import com.misw4203.vinilos.data.local.database.VinilosDatabase
@@ -32,4 +33,7 @@ object DatabaseModule {
 
     @Provides
     fun provideCollectorDao(db: VinilosDatabase): CollectorDao = db.collectorDao()
+
+    @Provides
+    fun provideBandDao(db: VinilosDatabase): BandDao = db.bandDao()
 }

--- a/app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt
@@ -1,9 +1,11 @@
 package com.misw4203.vinilos.di
 
 import com.misw4203.vinilos.data.repository.AlbumRepositoryImpl
+import com.misw4203.vinilos.data.repository.BandRepositoryImpl
 import com.misw4203.vinilos.data.repository.CollectorRepositoryImpl
 import com.misw4203.vinilos.data.repository.MusicianRepositoryImpl
 import com.misw4203.vinilos.domain.repository.AlbumRepository
+import com.misw4203.vinilos.domain.repository.BandRepository
 import com.misw4203.vinilos.domain.repository.CollectorRepository
 import com.misw4203.vinilos.domain.repository.MusicianRepository
 import dagger.Binds
@@ -27,4 +29,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindCollectorRepository(impl: CollectorRepositoryImpl): CollectorRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindBandRepository(impl: BandRepositoryImpl): BandRepository
 }

--- a/app/src/main/java/com/misw4203/vinilos/domain/model/AlbumDetail.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/model/AlbumDetail.kt
@@ -30,4 +30,5 @@ data class Comment(
     val id: Long,
     val description: String,
     val rating: Int,
+    val commenter: CollectorSummary? = null,
 )

--- a/app/src/main/java/com/misw4203/vinilos/domain/model/Band.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/model/Band.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.model
+
+data class Band(
+    val id: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val creationDate: String,
+    val members: List<MusicianSummary>,
+    val albums: List<Album>,
+)

--- a/app/src/main/java/com/misw4203/vinilos/domain/model/BandSummary.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/model/BandSummary.kt
@@ -1,0 +1,7 @@
+package com.misw4203.vinilos.domain.model
+
+data class BandSummary(
+    val id: Int,
+    val name: String,
+    val image: String,
+)

--- a/app/src/main/java/com/misw4203/vinilos/domain/repository/BandRepository.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/repository/BandRepository.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.domain.repository
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+
+interface BandRepository {
+    suspend fun getBands(): List<BandSummary>
+    suspend fun getBandDetail(id: Int): Band
+    suspend fun addMusicianToBand(bandId: Int, musicianId: Int)
+}

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCase.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class AddMusicianToBandUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(bandId: Int, musicianId: Int) =
+        repository.addMusicianToBand(bandId, musicianId)
+}

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCase.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class GetBandDetailUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(bandId: Int): Band = repository.getBandDetail(bandId)
+}

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCase.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class GetBandsUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(): List<BandSummary> = repository.getBands()
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
@@ -28,9 +28,17 @@ object Destinations {
 
     const val RefreshAlbumDetailKey = "refresh_album_detail"
 
+    const val BandDetail = "band/{bandId}"
+    const val BandDetailArg = "bandId"
+    const val AddMusiciansToBand = "band/{bandId}/musicians/add"
+    const val AddMusiciansBandArg = "bandId"
+    const val RefreshBandDetailKey = "refresh_band_detail"
+
     fun albumDetail(albumId: Long) = "album_detail/$albumId"
     fun collectorDetail(collectorId: Int) = "collector/$collectorId"
     fun addTrack(albumId: Long) = "album/$albumId/track/add"
     fun addComment(albumId: Long, collectorId: Int = DefaultCollectorId) =
         "album/$albumId/comment/add/$collectorId"
+    fun bandDetail(bandId: Int) = "band/$bandId"
+    fun addMusiciansToBand(bandId: Int) = "band/$bandId/musicians/add"
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.presentation.viewmodel.AlbumDetailViewModel

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -29,8 +29,10 @@ import com.misw4203.vinilos.presentation.ui.screens.album.AddTrackScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumListScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.CreateAlbumScreen
+import com.misw4203.vinilos.presentation.ui.screens.artist.ArtistsHubScreen
 import com.misw4203.vinilos.presentation.ui.screens.artist.MusicianDetailScreen
-import com.misw4203.vinilos.presentation.ui.screens.artist.MusicianListScreen
+import com.misw4203.vinilos.presentation.ui.screens.band.AddMusiciansToBandScreen
+import com.misw4203.vinilos.presentation.ui.screens.band.BandDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.collector.CollectorDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.collector.CollectorListScreen
 
@@ -153,8 +155,9 @@ fun VinilosNavHost() {
                     )
                 }
                 composable(Destinations.ArtistList) {
-                    MusicianListScreen(
+                    ArtistsHubScreen(
                         onMusicianClick = { id -> navController.navigate("artist/$id") },
+                        onBandClick = { id -> navController.navigate(Destinations.bandDetail(id)) },
                     )
                 }
                 composable(
@@ -180,6 +183,40 @@ fun VinilosNavHost() {
                     CollectorDetailScreen(
                         collectorId = collectorId,
                         onBack = { navController.popBackStack() },
+                    )
+                }
+                composable(
+                    route = Destinations.BandDetail,
+                    arguments = listOf(navArgument(Destinations.BandDetailArg) { type = NavType.IntType }),
+                ) { entry ->
+                    val bandId = entry.arguments?.getInt(Destinations.BandDetailArg) ?: return@composable
+                    val refreshFlag by entry.savedStateHandle
+                        .getStateFlow(Destinations.RefreshBandDetailKey, false)
+                        .collectAsStateWithLifecycle()
+                    BandDetailScreen(
+                        bandId = bandId,
+                        onBack = { navController.popBackStack() },
+                        onMusicianClick = { id -> navController.navigate("artist/$id") },
+                        onAddMusicians = {
+                            navController.navigate(Destinations.addMusiciansToBand(bandId))
+                        },
+                        refreshKey = refreshFlag,
+                        onRefreshHandled = {
+                            entry.savedStateHandle[Destinations.RefreshBandDetailKey] = false
+                        },
+                    )
+                }
+                composable(
+                    route = Destinations.AddMusiciansToBand,
+                    arguments = listOf(navArgument(Destinations.AddMusiciansBandArg) { type = NavType.IntType }),
+                ) {
+                    AddMusiciansToBandScreen(
+                        onBack = {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(Destinations.RefreshBandDetailKey, true)
+                            navController.popBackStack()
+                        },
                     )
                 }
             }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -44,7 +44,9 @@ fun VinilosNavHost() {
     val currentRoute = backStackEntry?.destination?.route
 
     val selectedDestination = when {
-        currentRoute == Destinations.ArtistList || currentRoute?.startsWith("artist/") == true -> VinilosDestination.Artists
+        currentRoute == Destinations.ArtistList ||
+            currentRoute?.startsWith("artist/") == true ||
+            currentRoute?.startsWith("band/") == true -> VinilosDestination.Artists
         currentRoute == Destinations.Collectors || currentRoute?.startsWith("collector/") == true -> VinilosDestination.Collectors
         else -> VinilosDestination.Albums
     }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/AlbumCard.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/AlbumCard.kt
@@ -23,12 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.Album
 
 @Composable
@@ -42,6 +43,7 @@ fun AlbumCard(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -53,7 +55,7 @@ fun AlbumCard(
         ) {
             AsyncImage(
                 model = album.coverUrl,
-                contentDescription = stringResource(R.string.cd_album_cover),
+                contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.size(72.dp),
             )
@@ -94,7 +96,7 @@ fun AlbumCard(
 
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(R.string.cd_open_album),
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.outlineVariant,
                 modifier = Modifier.padding(top = 4.dp),
             )

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/BandCard.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/BandCard.kt
@@ -1,0 +1,102 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.BandSummary
+
+@Composable
+fun BandCard(
+    band: BandSummary,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) { role = Role.Button }
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(CircleShape)
+                .background(Color(0xFF1A1A1A)),
+        ) {
+            AsyncImage(
+                model = band.image,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(72.dp),
+            )
+        }
+        Spacer(Modifier.width(20.dp))
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = band.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.size(4.dp))
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                ) {
+                    Text(
+                        text = stringResource(R.string.band_badge),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outlineVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/CollectorCard.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/CollectorCard.kt
@@ -23,10 +23,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.CollectorSummary
 
 @Composable
@@ -40,6 +41,7 @@ fun CollectorCard(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -52,7 +54,7 @@ fun CollectorCard(
         ) {
             Icon(
                 imageVector = Icons.Filled.Person,
-                contentDescription = stringResource(R.string.cd_collector_avatar),
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 modifier = Modifier.size(40.dp),
             )
@@ -76,7 +78,7 @@ fun CollectorCard(
             }
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(R.string.cd_open_collector),
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.outlineVariant,
             )
         }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersState.kt
@@ -1,0 +1,69 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.misw4203.vinilos.R
+
+@Composable
+fun EmptyMembersState(
+    onAddFirst: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Group,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Text(
+            text = stringResource(R.string.band_members_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(6.dp))
+        Text(
+            text = stringResource(R.string.band_members_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(20.dp))
+        Button(
+            onClick = onAddFirst,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+        ) {
+            Text(stringResource(R.string.add_first_member_cta))
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyState.kt
@@ -15,6 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
@@ -24,7 +27,8 @@ fun EmptyState(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(32.dp)
+            .semantics { liveRegion = LiveRegionMode.Polite },
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/ErrorState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/ErrorState.kt
@@ -18,6 +18,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
@@ -31,7 +34,8 @@ fun ErrorState(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(32.dp)
+            .semantics { liveRegion = LiveRegionMode.Assertive },
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/LoadingState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/LoadingState.kt
@@ -13,13 +13,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
 
 @Composable
 fun LoadingState(modifier: Modifier = Modifier) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .semantics { liveRegion = LiveRegionMode.Polite },
         contentAlignment = Alignment.Center,
     ) {
         Column(

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianCard.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianCard.kt
@@ -24,11 +24,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.MusicianSummary
 
 @Composable
@@ -42,6 +43,7 @@ fun MusicianCard(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -53,7 +55,7 @@ fun MusicianCard(
         ) {
             AsyncImage(
                 model = musician.image,
-                contentDescription = stringResource(R.string.cd_artist_image),
+                contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.size(72.dp),
             )
@@ -87,7 +89,7 @@ fun MusicianCard(
             }
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(R.string.cd_open_artist),
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.outlineVariant,
             )
         }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt
@@ -1,0 +1,121 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+@Composable
+fun MusicianRow(
+    musician: MusicianSummary,
+    isAdding: Boolean,
+    onAdd: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val addCd = stringResource(R.string.cd_add_musician_to_band, musician.name)
+    val addingCd = stringResource(R.string.cd_adding_musician)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF1A1A1A)),
+            ) {
+                AsyncImage(
+                    model = musician.image,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.size(48.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = musician.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (musician.birthDate.isNotBlank()) {
+                    Text(
+                        text = musician.birthDate.take(10),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        }
+        if (isAdding) {
+            Box(
+                modifier = Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                    .semantics { contentDescription = addingCd },
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                    .clickable { onAdd(musician.id) }
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = addCd
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Add,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt
@@ -82,6 +82,8 @@ fun MusicianRow(
                         text = musician.birthDate.take(10),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.outline,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/PerformerHeader.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/PerformerHeader.kt
@@ -1,0 +1,90 @@
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+
+@Composable
+fun PerformerHeader(
+    name: String,
+    image: String,
+    description: String,
+    badgeKind: PerformerBadgeKind,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AsyncImage(
+            model = image,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(8.dp))
+        Surface(
+            shape = RoundedCornerShape(50),
+            color = MaterialTheme.colorScheme.primaryContainer,
+        ) {
+            Text(
+                text = when (badgeKind) {
+                    PerformerBadgeKind.Band -> stringResource(R.string.band_badge)
+                    PerformerBadgeKind.Artist -> stringResource(R.string.artist_badge)
+                },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.sp,
+            )
+        }
+        if (description.isNotBlank()) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+enum class PerformerBadgeKind { Band, Artist }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/RatingBar.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/RatingBar.kt
@@ -2,20 +2,31 @@ package com.misw4203.vinilos.presentation.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
+
+private val MinTouchTarget = 48.dp
 
 @Composable
 fun RatingBar(
@@ -25,26 +36,60 @@ fun RatingBar(
     starSize: Dp = 36.dp,
     interactive: Boolean = true,
 ) {
+    val rowModifier = if (interactive) {
+        modifier
+    } else {
+        val summary = stringResource(R.string.cd_rating_summary, rating)
+        modifier.clearAndSetSemantics { contentDescription = summary }
+    }
     Row(
-        modifier = modifier,
+        modifier = rowModifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         (1..5).forEach { star ->
             val isFilled = star <= rating
-            val cd = stringResource(R.string.cd_rating, star)
-            val starModifier = Modifier
-                .size(starSize)
-                .testTag("rating_star_$star")
-                .let {
-                    if (interactive) it.clickable { onRatingChange(star) } else it
+            if (interactive) {
+                val actionDesc = stringResource(R.string.cd_rate_with_stars, star)
+                val stateDesc = stringResource(
+                    if (isFilled) R.string.cd_state_selected else R.string.cd_state_not_selected
+                )
+                Box(
+                    modifier = Modifier
+                        .sizeIn(minWidth = MinTouchTarget, minHeight = MinTouchTarget)
+                        .clickable { onRatingChange(star) }
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = actionDesc
+                            stateDescription = stateDesc
+                        }
+                        .testTag("rating_star_$star"),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    StarIcon(isFilled = isFilled, starSize = starSize)
                 }
-            Icon(
-                imageVector = if (isFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                contentDescription = cd,
-                tint = if (isFilled) MaterialTheme.colorScheme.primary
-                else MaterialTheme.colorScheme.outlineVariant,
-                modifier = starModifier,
-            )
+            } else {
+                StarIcon(
+                    isFilled = isFilled,
+                    starSize = starSize,
+                    modifier = Modifier.testTag("rating_star_$star"),
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun StarIcon(
+    isFilled: Boolean,
+    starSize: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = if (isFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
+        contentDescription = null,
+        tint = if (isFilled) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.outlineVariant,
+        modifier = modifier.size(starSize),
+    )
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/SearchBarStatic.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/SearchBarStatic.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
 
@@ -26,6 +28,7 @@ fun SearchBarStatic(
     modifier: Modifier = Modifier,
     placeholder: String = stringResource(R.string.search_placeholder),
 ) {
+    val description = stringResource(R.string.cd_search_field, placeholder)
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -36,7 +39,8 @@ fun SearchBarStatic(
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.15f),
                 shape = RoundedCornerShape(12.dp),
             )
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics(mergeDescendants = true) { contentDescription = description },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
@@ -87,7 +91,11 @@ private fun NavTab(
     Column(
         modifier = modifier
             .clickable(onClick = onClick)
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .semantics(mergeDescendants = true) {
+                role = Role.Tab
+                selected = active
+            }
+            .padding(horizontal = 12.dp, vertical = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(24.dp))

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosTopBar.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosTopBar.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.misw4203.vinilos.R
 
@@ -50,6 +52,7 @@ fun VinilosTopBar(
                 text = title,
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.semantics { heading() },
             )
         }
         Box(

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.presentation.ui.components.RatingBar
@@ -114,7 +114,7 @@ fun AddCommentScreen(
                         )
                     }
                 },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                 ),
             )

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -94,6 +96,7 @@ fun AddCommentScreen(
                         text = stringResource(R.string.add_comment_title),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 navigationIcon = {
@@ -259,6 +262,7 @@ private fun SectionHeading(text: String) {
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.semantics { heading() },
         )
     }
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddCommentScreen.kt
@@ -160,10 +160,6 @@ private fun AddCommentContent(
             rating = form.rating,
             onRatingChange = onRatingChange,
         )
-        if (form.ratingError == FormError.InvalidRating) {
-            Spacer(Modifier.height(6.dp))
-            ErrorText(stringResource(R.string.add_comment_error_rating))
-        }
 
         Spacer(Modifier.height(24.dp))
 
@@ -277,11 +273,3 @@ private fun FieldLabel(text: String) {
     )
 }
 
-@Composable
-private fun ErrorText(message: String) {
-    Text(
-        text = message,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.error,
-    )
-}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddTrackScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddTrackScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -82,7 +84,12 @@ fun AddTrackScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.add_track_title)) },
+                title = {
+                    Text(
+                        text = stringResource(R.string.add_track_title),
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -114,6 +121,7 @@ fun AddTrackScreen(
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.semantics { heading() },
             )
 
             OutlinedTextField(
@@ -187,7 +195,8 @@ private fun AlbumHeaderCard(album: AlbumDetail) {
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(12.dp),
+            .padding(12.dp)
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddTrackScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AddTrackScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumDetailScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -119,7 +120,7 @@ private fun AlbumDetailContent(
             Box(modifier = Modifier.fillMaxWidth().height(CoverHeight)) {
                 AsyncImage(
                     model = album.coverUrl,
-                    contentDescription = stringResource(R.string.cd_album_cover),
+                    contentDescription = stringResource(R.string.cd_album_cover_of, album.name),
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxSize(),
                 )
@@ -141,6 +142,7 @@ private fun AlbumDetailContent(
                         style = MaterialTheme.typography.headlineLarge,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.semantics { heading() },
                     )
                     if (album.artistName.isNotBlank()) {
                         Spacer(Modifier.height(4.dp))
@@ -307,12 +309,18 @@ private fun TracksSection(tracks: List<Track>, onAddTrack: () -> Unit) {
 
 @Composable
 private fun TrackRow(index: Int, track: Track) {
+    val rowDesc = if (track.duration.isNotBlank()) {
+        stringResource(R.string.cd_track_with_duration, index, track.name, track.duration)
+    } else {
+        stringResource(R.string.cd_track_no_duration, index, track.name)
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics(mergeDescendants = true) { contentDescription = rowDesc },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -354,7 +362,8 @@ private fun PerformerChip(performer: Performer) {
         modifier = Modifier
             .clip(RoundedCornerShape(999.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -431,6 +440,7 @@ private fun SectionHeader(title: String) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.semantics { heading() },
     )
 }
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/AlbumListScreen.kt
@@ -20,13 +20,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/CreateAlbumScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/CreateAlbumScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -76,7 +76,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R
@@ -531,7 +531,7 @@ private fun GenreDropdown(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                 .testTag("create_album_genre"),
         )
         ExposedDropdownMenu(
@@ -582,7 +582,7 @@ private fun RecordLabelDropdown(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                 .testTag("create_album_record_label"),
         )
         ExposedDropdownMenu(

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/CreateAlbumScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/album/CreateAlbumScreen.kt
@@ -70,6 +70,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -162,6 +164,7 @@ fun CreateAlbumScreen(
                     Text(
                         text = stringResource(R.string.create_album_title),
                         style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 navigationIcon = {
@@ -231,6 +234,7 @@ fun CreateAlbumScreen(
                             text = stringResource(R.string.create_album_section_title),
                             style = MaterialTheme.typography.headlineSmall,
                             color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.semantics { heading() },
                         )
                         Text(
                             text = stringResource(R.string.create_album_section_subtitle),
@@ -433,6 +437,7 @@ private fun SectionLabel(text: String) {
         style = MaterialTheme.typography.labelSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         letterSpacing = androidx.compose.ui.unit.TextUnit(0.12f, androidx.compose.ui.unit.TextUnitType.Em),
+        modifier = Modifier.semantics { heading() },
     )
 }
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ArtistsHubScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ArtistsHubScreen.kt
@@ -1,0 +1,54 @@
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
+import com.misw4203.vinilos.presentation.ui.screens.band.BandListContent
+
+@Composable
+fun ArtistsHubScreen(
+    onMusicianClick: (Int) -> Unit,
+    onBandClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        VinilosTopBar(title = stringResource(R.string.artists_title))
+        TabRow(
+            selectedTabIndex = selectedTab,
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { selectedTab = 0 },
+                modifier = Modifier.testTag("artists_tab_musicians"),
+                text = { Text(stringResource(R.string.artists_tab_musicians)) },
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { selectedTab = 1 },
+                modifier = Modifier.testTag("artists_tab_bands"),
+                text = { Text(stringResource(R.string.artists_tab_bands)) },
+            )
+        }
+        when (selectedTab) {
+            0 -> MusicianListContent(onMusicianClick = onMusicianClick)
+            1 -> BandListContent(onBandClick = onBandClick)
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ArtistsHubScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ArtistsHubScreen.kt
@@ -3,8 +3,8 @@ package com.misw4203.vinilos.presentation.ui.screens.artist
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,7 +28,7 @@ fun ArtistsHubScreen(
 
     Column(modifier = modifier.fillMaxSize()) {
         VinilosTopBar(title = stringResource(R.string.artists_title))
-        TabRow(
+        PrimaryTabRow(
             selectedTabIndex = selectedTab,
             containerColor = MaterialTheme.colorScheme.surface,
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
@@ -48,6 +48,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -82,6 +86,7 @@ fun MusicianDetailScreen(
                     Text(
                         text = stringResource(R.string.artist_detail_title),
                         fontWeight = FontWeight.Bold,
+                        modifier = Modifier.semantics { heading() },
                     )
                 },
                 navigationIcon = {
@@ -162,7 +167,7 @@ private fun ArtistHeader(musician: Musician) {
     ) {
         AsyncImage(
             model = musician.image,
-            contentDescription = musician.name,
+            contentDescription = stringResource(R.string.cd_artist_photo_of, musician.name),
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(120.dp)
@@ -175,6 +180,7 @@ private fun ArtistHeader(musician: Musician) {
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(Modifier.height(8.dp))
         Surface(
@@ -210,6 +216,7 @@ private fun SectionHeader(title: String) {
             text = title,
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
         )
         Spacer(Modifier.width(12.dp))
         HorizontalDivider(
@@ -248,10 +255,14 @@ private fun AlbumsSection(albums: List<Album>) {
 
 @Composable
 private fun AlbumCard(album: Album) {
-    Column(modifier = Modifier.width(120.dp)) {
+    Column(
+        modifier = Modifier
+            .width(120.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
         AsyncImage(
             model = album.coverUrl,
-            contentDescription = album.name,
+            contentDescription = stringResource(R.string.cd_album_cover_of, album.name),
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(120.dp)
@@ -319,6 +330,7 @@ private fun PrizeItem(prize: MusicianPrize, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() }
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .testTag("prize_${prize.id}"),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListContent.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListContent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.presentation.ui.components.EmptyState

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListContent.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListContent.kt
@@ -1,0 +1,87 @@
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.EmptyState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
+import com.misw4203.vinilos.presentation.viewmodel.MusicianListUiState
+import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
+
+@Composable
+fun MusicianListContent(
+    onMusicianClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MusicianListViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is MusicianListUiState.Loading -> LoadingState()
+            is MusicianListUiState.Error -> ErrorState(
+                onRetry = viewModel::retry,
+                isNetworkError = state.isNetworkError,
+            )
+            is MusicianListUiState.Empty -> Column {
+                MusicianHeaderSection()
+                EmptyState()
+            }
+            is MusicianListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("artists_list"),
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                item { MusicianHeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.artists_record_count,
+                            state.musicians.size,
+                            state.musicians.size,
+                        ),
+                        testTag = "artists_record_count",
+                    )
+                }
+                items(state.musicians, key = { it.id }) { musician ->
+                    MusicianCard(
+                        musician = musician,
+                        onClick = { onMusicianClick(musician.id) },
+                        modifier = Modifier.testTag("musician_card_${musician.id}"),
+                    )
+                }
+                item { Spacer(Modifier.size(24.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MusicianHeaderSection() {
+    Column {
+        SearchBarStatic(placeholder = stringResource(R.string.search_placeholder_artists))
+        Spacer(Modifier.size(8.dp))
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
@@ -1,32 +1,8 @@
 package com.misw4203.vinilos.presentation.ui.screens.artist
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.misw4203.vinilos.R
-import androidx.compose.ui.res.pluralStringResource
-import com.misw4203.vinilos.presentation.ui.components.EmptyState
-import com.misw4203.vinilos.presentation.ui.components.ErrorState
-import com.misw4203.vinilos.presentation.ui.components.ListCounter
-import com.misw4203.vinilos.presentation.ui.components.LoadingState
-import com.misw4203.vinilos.presentation.ui.components.MusicianCard
-import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
-import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
-import com.misw4203.vinilos.presentation.viewmodel.MusicianListUiState
 import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
 
 @Composable
@@ -35,55 +11,9 @@ fun MusicianListScreen(
     modifier: Modifier = Modifier,
     viewModel: MusicianListViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val listState = rememberLazyListState()
-
-    Column(modifier = modifier.fillMaxSize()) {
-        VinilosTopBar(title = stringResource(R.string.artists_title))
-        when (val state = uiState) {
-            is MusicianListUiState.Loading -> LoadingState()
-            is MusicianListUiState.Error -> ErrorState(
-                onRetry = viewModel::retry,
-                isNetworkError = state.isNetworkError,
-            )
-            is MusicianListUiState.Empty -> Column {
-                HeaderSection()
-                EmptyState()
-            }
-            is MusicianListUiState.Success -> LazyColumn(
-                modifier = Modifier.testTag("artists_list"),
-                state = listState,
-                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(24.dp),
-            ) {
-                item { HeaderSection() }
-                item {
-                    ListCounter(
-                        text = pluralStringResource(
-                            R.plurals.artists_record_count,
-                            state.musicians.size,
-                            state.musicians.size,
-                        ),
-                        testTag = "artists_record_count",
-                    )
-                }
-                items(state.musicians, key = { it.id }) { musician ->
-                    MusicianCard(
-                        musician = musician,
-                        onClick = { onMusicianClick(musician.id) },
-                        modifier = Modifier.testTag("musician_card_${musician.id}"),
-                    )
-                }
-                item { Spacer(Modifier.size(24.dp)) }
-            }
-        }
-    }
-}
-
-@Composable
-private fun HeaderSection() {
-    Column {
-        SearchBarStatic(placeholder = stringResource(R.string.search_placeholder_artists))
-        Spacer(Modifier.size(8.dp))
-    }
+    MusicianListContent(
+        onMusicianClick = onMusicianClick,
+        modifier = modifier,
+        viewModel = viewModel,
+    )
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt
@@ -2,7 +2,7 @@ package com.misw4203.vinilos.presentation.ui.screens.artist
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
 
 @Composable

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.MusicianSummary

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
@@ -1,0 +1,207 @@
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.MusicianRow
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansEvent
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansUiState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddMusiciansToBandScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddMusiciansToBandViewModel = hiltViewModel(),
+) {
+    val form by viewModel.form.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val successTemplate = stringResource(R.string.add_musician_success)
+    val networkErrorMessage = stringResource(R.string.add_musician_error_network)
+    val serverErrorMessage = stringResource(R.string.add_musician_error_server)
+
+    LaunchedEffect(viewModel.events) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is AddMusiciansEvent.AddedSuccessfully ->
+                    snackbarHostState.showSnackbar(successTemplate.format(event.musicianName))
+            }
+        }
+    }
+    LaunchedEffect(uiState) {
+        val state = uiState
+        if (state is AddMusiciansUiState.Error && state.musicianId != null) {
+            val msg = if (state.isNetworkError) networkErrorMessage else serverErrorMessage
+            snackbarHostState.showSnackbar(msg)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag("add_musicians_screen_root"),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.add_musicians_title),
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("add_musicians_back")) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (uiState) {
+                AddMusiciansUiState.Loading -> LoadingState()
+                else -> Content(
+                    queryValue = form.query,
+                    onQueryChange = viewModel::onQueryChange,
+                    available = form.filteredAvailable,
+                    currentMembers = form.allMusicians.filter { it.id in form.currentMemberIds },
+                    addingId = (uiState as? AddMusiciansUiState.Adding)?.musicianId,
+                    onAdd = viewModel::onAddMusician,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun Content(
+    queryValue: String,
+    onQueryChange: (String) -> Unit,
+    available: List<MusicianSummary>,
+    currentMembers: List<MusicianSummary>,
+    addingId: Int?,
+    onAdd: (Int) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            OutlinedTextField(
+                value = queryValue,
+                onValueChange = onQueryChange,
+                placeholder = { Text(stringResource(R.string.search_musicians_placeholder)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("add_musicians_search"),
+            )
+        }
+        item {
+            SectionHeader(stringResource(R.string.add_musicians_available_section))
+        }
+        if (available.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(R.string.add_musicians_empty_filter),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            items(available, key = { it.id }) { musician ->
+                MusicianRow(
+                    musician = musician,
+                    isAdding = addingId == musician.id,
+                    onAdd = onAdd,
+                    modifier = Modifier.testTag("available_musician_${musician.id}"),
+                )
+            }
+        }
+        item {
+            SectionHeader(stringResource(R.string.add_musicians_current_section))
+        }
+        item {
+            Text(
+                text = pluralStringResource(
+                    R.plurals.members_record_count,
+                    currentMembers.size,
+                    currentMembers.size,
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+        items(currentMembers, key = { it.id }) { musician ->
+            MusicianCard(
+                musician = musician,
+                onClick = {},
+                modifier = Modifier.testTag("current_member_${musician.id}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        letterSpacing = 1.sp,
+        modifier = Modifier.semantics { heading() },
+    )
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt
@@ -1,13 +1,20 @@
 package com.misw4203.vinilos.presentation.ui.screens.band
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -26,7 +33,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -39,8 +49,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
 import com.misw4203.vinilos.presentation.ui.components.LoadingState
-import com.misw4203.vinilos.presentation.ui.components.MusicianCard
 import com.misw4203.vinilos.presentation.ui.components.MusicianRow
 import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansEvent
 import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
@@ -61,19 +71,16 @@ fun AddMusiciansToBandScreen(
     val networkErrorMessage = stringResource(R.string.add_musician_error_network)
     val serverErrorMessage = stringResource(R.string.add_musician_error_server)
 
-    LaunchedEffect(viewModel.events) {
+    LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 is AddMusiciansEvent.AddedSuccessfully ->
                     snackbarHostState.showSnackbar(successTemplate.format(event.musicianName))
+                is AddMusiciansEvent.AddFailed -> {
+                    val msg = if (event.isNetworkError) networkErrorMessage else serverErrorMessage
+                    snackbarHostState.showSnackbar(msg)
+                }
             }
-        }
-    }
-    LaunchedEffect(uiState) {
-        val state = uiState
-        if (state is AddMusiciansUiState.Error && state.musicianId != null) {
-            val msg = if (state.isNetworkError) networkErrorMessage else serverErrorMessage
-            snackbarHostState.showSnackbar(msg)
         }
     }
 
@@ -100,8 +107,23 @@ fun AddMusiciansToBandScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
-            when (uiState) {
+            when (val s = uiState) {
                 AddMusiciansUiState.Loading -> LoadingState()
+                is AddMusiciansUiState.Error -> if (s.musicianId == null) {
+                    ErrorState(
+                        onRetry = viewModel::retry,
+                        isNetworkError = s.isNetworkError,
+                    )
+                } else {
+                    Content(
+                        queryValue = form.query,
+                        onQueryChange = viewModel::onQueryChange,
+                        available = form.filteredAvailable,
+                        currentMembers = form.allMusicians.filter { it.id in form.currentMemberIds },
+                        addingId = null,
+                        onAdd = viewModel::onAddMusician,
+                    )
+                }
                 else -> Content(
                     queryValue = form.query,
                     onQueryChange = viewModel::onQueryChange,
@@ -158,6 +180,7 @@ private fun Content(
                     text = stringResource(R.string.add_musicians_empty_filter),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("add_musicians_empty_filter"),
                 )
             }
         } else {
@@ -185,11 +208,56 @@ private fun Content(
             )
         }
         items(currentMembers, key = { it.id }) { musician ->
-            MusicianCard(
+            CurrentMemberItem(
                 musician = musician,
-                onClick = {},
                 modifier = Modifier.testTag("current_member_${musician.id}"),
             )
+        }
+    }
+}
+
+@Composable
+private fun CurrentMemberItem(
+    musician: MusicianSummary,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .background(Color(0xFF1A1A1A)),
+        ) {
+            coil.compose.AsyncImage(
+                model = musician.image,
+                contentDescription = null,
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier.size(48.dp),
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(
+                text = musician.name,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+            )
+            if (musician.birthDate.isNotBlank()) {
+                Text(
+                    text = musician.birthDate.take(10),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreen.kt
@@ -1,0 +1,283 @@
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.PersonAdd
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.presentation.ui.components.EmptyMembersState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.PerformerBadgeKind
+import com.misw4203.vinilos.presentation.ui.components.PerformerHeader
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailUiState
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BandDetailScreen(
+    bandId: Int,
+    onBack: () -> Unit,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+    modifier: Modifier = Modifier,
+    refreshKey: Boolean = false,
+    onRefreshHandled: () -> Unit = {},
+    viewModel: BandDetailViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(bandId) { viewModel.loadBand(bandId) }
+    LaunchedEffect(refreshKey) {
+        if (refreshKey) {
+            viewModel.retry()
+            onRefreshHandled()
+        }
+    }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.band_detail_title),
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("band_detail_back")) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (val state = uiState) {
+                is BandDetailUiState.Loading -> LoadingState()
+                is BandDetailUiState.NotFound -> NotFoundContent()
+                is BandDetailUiState.Error -> ErrorState(
+                    onRetry = viewModel::retry,
+                    isNetworkError = state.isNetworkError,
+                )
+                is BandDetailUiState.Success -> BandBody(
+                    band = state.band,
+                    onMusicianClick = onMusicianClick,
+                    onAddMusicians = onAddMusicians,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandBody(
+    band: Band,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .testTag("band_detail_root"),
+    ) {
+        PerformerHeader(
+            name = band.name,
+            image = band.image,
+            description = band.description,
+            badgeKind = PerformerBadgeKind.Band,
+            contentDescription = stringResource(R.string.cd_band_image_of, band.name),
+        )
+        Spacer(Modifier.height(8.dp))
+
+        MembersSection(
+            members = band.members,
+            onMusicianClick = onMusicianClick,
+            onAddMusicians = onAddMusicians,
+        )
+
+        if (band.albums.isNotEmpty()) {
+            Spacer(Modifier.height(24.dp))
+            AlbumsSection(band.albums)
+        }
+
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun MembersSection(
+    members: List<MusicianSummary>,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+) {
+    SectionHeader(stringResource(R.string.band_members_section_title))
+    Spacer(Modifier.height(8.dp))
+    if (members.isEmpty()) {
+        EmptyMembersState(onAddFirst = onAddMusicians)
+    } else {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            members.forEach { m ->
+                MusicianCard(
+                    musician = m,
+                    onClick = { onMusicianClick(m.id) },
+                    modifier = Modifier.testTag("current_member_${m.id}"),
+                )
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Button(
+            onClick = onAddMusicians,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .height(48.dp)
+                .testTag("band_detail_add_musicians"),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.PersonAdd,
+                contentDescription = null,
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.add_musicians_cta))
+        }
+    }
+}
+
+@Composable
+private fun AlbumsSection(albums: List<Album>) {
+    SectionHeader(stringResource(R.string.band_albums_section_title))
+    Spacer(Modifier.height(8.dp))
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        items(albums) { album ->
+            Column(modifier = Modifier.width(120.dp)) {
+                AsyncImage(
+                    model = album.coverUrl,
+                    contentDescription = stringResource(R.string.cd_album_cover_of, album.name),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = album.name,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (album.releaseYear.isNotBlank()) {
+                    Text(
+                        text = album.releaseYear,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Box(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
+        )
+    }
+}
+
+@Composable
+private fun NotFoundContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.band_not_found_title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.band_not_found_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandListContent.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandListContent.kt
@@ -1,0 +1,87 @@
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.BandCard
+import com.misw4203.vinilos.presentation.ui.components.EmptyState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
+import com.misw4203.vinilos.presentation.viewmodel.BandListUiState
+import com.misw4203.vinilos.presentation.viewmodel.BandListViewModel
+
+@Composable
+fun BandListContent(
+    onBandClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BandListViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is BandListUiState.Loading -> LoadingState()
+            is BandListUiState.Error -> ErrorState(
+                onRetry = viewModel::retry,
+                isNetworkError = state.isNetworkError,
+            )
+            is BandListUiState.Empty -> Column {
+                BandHeaderSection()
+                EmptyState()
+            }
+            is BandListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("bands_list"),
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                item { BandHeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.bands_record_count,
+                            state.bands.size,
+                            state.bands.size,
+                        ),
+                        testTag = "bands_record_count",
+                    )
+                }
+                items(state.bands, key = { it.id }) { band ->
+                    BandCard(
+                        band = band,
+                        onClick = { onBandClick(band.id) },
+                        modifier = Modifier.testTag("band_card_${band.id}"),
+                    )
+                }
+                item { Spacer(Modifier.size(24.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandHeaderSection() {
+    Column {
+        SearchBarStatic(placeholder = stringResource(R.string.search_placeholder_bands))
+        Spacer(Modifier.size(8.dp))
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandListContent.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandListContent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import com.misw4203.vinilos.presentation.ui.components.BandCard

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -140,13 +141,18 @@ private fun CollectorDetailContent(collector: CollectorDetail, onBack: () -> Uni
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface,
                             textAlign = TextAlign.Center,
+                            modifier = Modifier.semantics { heading() },
                         )
 
                         // Email
+                        val emailDesc = stringResource(R.string.cd_collector_email, collector.email)
                         Spacer(Modifier.height(12.dp))
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.semantics(mergeDescendants = true) {
+                                contentDescription = emailDesc
+                            },
                         ) {
                             Icon(
                                 imageVector = Icons.Filled.Mail,
@@ -162,10 +168,14 @@ private fun CollectorDetailContent(collector: CollectorDetail, onBack: () -> Uni
                         }
 
                         // Telephone
+                        val phoneDesc = stringResource(R.string.cd_collector_phone, collector.telephone)
                         Spacer(Modifier.height(4.dp))
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.semantics(mergeDescendants = true) {
+                                contentDescription = phoneDesc
+                            },
                         ) {
                             Icon(
                                 imageVector = Icons.Filled.Phone,
@@ -241,6 +251,7 @@ private fun SectionHeader(title: String) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.semantics { heading() },
     )
 }
 
@@ -259,10 +270,17 @@ private fun AlbumsSection(albums: List<CollectorAlbum>) {
 
 @Composable
 private fun CollectorAlbumCard(collectorAlbum: CollectorAlbum) {
-    Column(modifier = Modifier.width(120.dp)) {
+    val albumName = collectorAlbum.album?.name.orEmpty()
+    Column(
+        modifier = Modifier
+            .width(120.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
         AsyncImage(
             model = collectorAlbum.album?.coverUrl,
-            contentDescription = collectorAlbum.album?.name,
+            contentDescription = if (albumName.isNotBlank()) {
+                stringResource(R.string.cd_album_cover_of, albumName)
+            } else null,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .size(120.dp)
@@ -336,7 +354,8 @@ private fun PerformerChip(performer: Performer) {
         modifier = Modifier
             .clip(RoundedCornerShape(999.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.R

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorListScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.misw4203.vinilos.R
 import androidx.compose.ui.res.pluralStringResource

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentUiState.kt
@@ -13,10 +13,8 @@ data class AddCommentFormState(
     val description: String = "",
     val rating: Int = 0,
     val descriptionError: FormError? = null,
-    val ratingError: FormError? = null,
 )
 
 enum class FormError {
     EmptyDescription,
-    InvalidRating,
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModel.kt
@@ -35,18 +35,15 @@ class AddCommentViewModel @Inject constructor(
     }
 
     fun onRatingChange(value: Int) {
-        _form.update { it.copy(rating = value.coerceIn(0, 5), ratingError = null) }
+        _form.update { it.copy(rating = value.coerceIn(0, 5)) }
     }
 
     fun submit() {
         val current = _form.value
         val descriptionError = if (current.description.isBlank()) FormError.EmptyDescription else null
-        val ratingError = if (current.rating < 1) FormError.InvalidRating else null
 
-        if (descriptionError != null || ratingError != null) {
-            _form.update {
-                it.copy(descriptionError = descriptionError, ratingError = ratingError)
-            }
+        if (descriptionError != null) {
+            _form.update { it.copy(descriptionError = descriptionError) }
             return
         }
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansFormState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansFormState.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+data class AddMusiciansFormState(
+    val query: String = "",
+    val allMusicians: List<MusicianSummary> = emptyList(),
+    val currentMemberIds: Set<Int> = emptySet(),
+    val filteredAvailable: List<MusicianSummary> = emptyList(),
+)

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
@@ -7,6 +7,7 @@ import com.misw4203.vinilos.domain.model.MusicianSummary
 import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
 import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
 import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
@@ -37,8 +38,9 @@ class AddMusiciansToBandViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val bandId: Int = savedStateHandle.get<Int>("bandId")
-        ?: error("AddMusiciansToBandViewModel requires bandId in SavedStateHandle")
+    private val bandId: Int = checkNotNull(savedStateHandle.get<Int>(Destinations.AddMusiciansBandArg)) {
+        "AddMusiciansToBandViewModel requires bandId in SavedStateHandle"
+    }
 
     private val _form = MutableStateFlow(AddMusiciansFormState())
     val form: StateFlow<AddMusiciansFormState> = _form.asStateFlow()

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
@@ -1,0 +1,152 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import java.text.Normalizer
+import javax.inject.Inject
+
+@OptIn(FlowPreview::class)
+@HiltViewModel
+class AddMusiciansToBandViewModel @Inject constructor(
+    private val getMusicians: GetMusiciansUseCase,
+    private val getBandDetail: GetBandDetailUseCase,
+    private val addMusicianToBand: AddMusicianToBandUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val bandId: Int = savedStateHandle.get<Int>("bandId")
+        ?: error("AddMusiciansToBandViewModel requires bandId in SavedStateHandle")
+
+    private val _form = MutableStateFlow(AddMusiciansFormState())
+    val form: StateFlow<AddMusiciansFormState> = _form.asStateFlow()
+
+    private val _uiState = MutableStateFlow<AddMusiciansUiState>(AddMusiciansUiState.Loading)
+    val uiState: StateFlow<AddMusiciansUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<AddMusiciansEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AddMusiciansEvent> = _events.asSharedFlow()
+
+    private val queryChannel = MutableStateFlow("")
+
+    init {
+        loadInitial()
+        queryChannel
+            .debounce(300L)
+            .distinctUntilChanged()
+            .onEach { q ->
+                _form.value = _form.value.copy(
+                    query = q,
+                    filteredAvailable = computeFiltered(_form.value.allMusicians, _form.value.currentMemberIds, q),
+                )
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onQueryChange(query: String) {
+        queryChannel.value = query
+    }
+
+    fun onAddMusician(musicianId: Int) {
+        if (_uiState.value is AddMusiciansUiState.Adding) return
+        _uiState.value = AddMusiciansUiState.Adding(musicianId)
+        viewModelScope.launch {
+            try {
+                addMusicianToBand(bandId, musicianId)
+                val musician = _form.value.allMusicians.firstOrNull { it.id == musicianId }
+                _form.value = _form.value.copy(
+                    currentMemberIds = _form.value.currentMemberIds + musicianId,
+                    filteredAvailable = computeFiltered(
+                        _form.value.allMusicians,
+                        _form.value.currentMemberIds + musicianId,
+                        _form.value.query,
+                    ),
+                )
+                _uiState.value = AddMusiciansUiState.Ready
+                if (musician != null) {
+                    _events.tryEmit(AddMusiciansEvent.AddedSuccessfully(musician.name))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = true, musicianId = musicianId)
+            } catch (e: HttpException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+            } catch (e: Exception) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+            }
+        }
+    }
+
+    private fun loadInitial() {
+        _uiState.value = AddMusiciansUiState.Loading
+        viewModelScope.launch {
+            try {
+                coroutineScope {
+                    val musiciansAsync = async { getMusicians() }
+                    val bandAsync = async { getBandDetail(bandId) }
+                    val musicians = musiciansAsync.await()
+                    val band = bandAsync.await()
+                    val memberIds = band.members.map { it.id }.toSet()
+                    _form.value = AddMusiciansFormState(
+                        query = "",
+                        allMusicians = musicians,
+                        currentMemberIds = memberIds,
+                        filteredAvailable = computeFiltered(musicians, memberIds, ""),
+                    )
+                    _uiState.value = AddMusiciansUiState.Ready
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = true, musicianId = null)
+            } catch (e: HttpException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = null)
+            } catch (e: Exception) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = null)
+            }
+        }
+    }
+
+    fun retry() {
+        loadInitial()
+    }
+
+    private fun computeFiltered(
+        all: List<MusicianSummary>,
+        excluded: Set<Int>,
+        query: String,
+    ): List<MusicianSummary> {
+        val available = all.filterNot { it.id in excluded }
+        if (query.isBlank()) return available
+        val normalizedQuery = normalize(query)
+        return available.filter { normalize(it.name).contains(normalizedQuery) }
+    }
+
+    private fun normalize(text: String): String {
+        val nfd = Normalizer.normalize(text, Normalizer.Form.NFD)
+        return nfd.replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "").lowercase()
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
@@ -94,10 +94,13 @@ class AddMusiciansToBandViewModel @Inject constructor(
                 throw e
             } catch (e: IOException) {
                 _uiState.value = AddMusiciansUiState.Error(isNetworkError = true, musicianId = musicianId)
+                _events.tryEmit(AddMusiciansEvent.AddFailed(isNetworkError = true))
             } catch (e: HttpException) {
                 _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+                _events.tryEmit(AddMusiciansEvent.AddFailed(isNetworkError = false))
             } catch (e: Exception) {
                 _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+                _events.tryEmit(AddMusiciansEvent.AddFailed(isNetworkError = false))
             }
         }
     }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt
@@ -10,7 +10,6 @@ import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
 import com.misw4203.vinilos.presentation.navigation.Destinations
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -19,17 +18,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.io.IOException
 import java.text.Normalizer
 import javax.inject.Inject
 
-@OptIn(FlowPreview::class)
 @HiltViewModel
 class AddMusiciansToBandViewModel @Inject constructor(
     private val getMusicians: GetMusiciansUseCase,
@@ -51,24 +45,15 @@ class AddMusiciansToBandViewModel @Inject constructor(
     private val _events = MutableSharedFlow<AddMusiciansEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<AddMusiciansEvent> = _events.asSharedFlow()
 
-    private val queryChannel = MutableStateFlow("")
-
     init {
         loadInitial()
-        queryChannel
-            .debounce(300L)
-            .distinctUntilChanged()
-            .onEach { q ->
-                _form.value = _form.value.copy(
-                    query = q,
-                    filteredAvailable = computeFiltered(_form.value.allMusicians, _form.value.currentMemberIds, q),
-                )
-            }
-            .launchIn(viewModelScope)
     }
 
     fun onQueryChange(query: String) {
-        queryChannel.value = query
+        _form.value = _form.value.copy(
+            query = query,
+            filteredAvailable = computeFiltered(_form.value.allMusicians, _form.value.currentMemberIds, query),
+        )
     }
 
     fun onAddMusician(musicianId: Int) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansUiState.kt
@@ -9,4 +9,5 @@ sealed interface AddMusiciansUiState {
 
 sealed interface AddMusiciansEvent {
     data class AddedSuccessfully(val musicianName: String) : AddMusiciansEvent
+    data class AddFailed(val isNetworkError: Boolean) : AddMusiciansEvent
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansUiState.kt
@@ -1,0 +1,12 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+sealed interface AddMusiciansUiState {
+    data object Loading : AddMusiciansUiState
+    data object Ready : AddMusiciansUiState
+    data class Adding(val musicianId: Int) : AddMusiciansUiState
+    data class Error(val isNetworkError: Boolean, val musicianId: Int?) : AddMusiciansUiState
+}
+
+sealed interface AddMusiciansEvent {
+    data class AddedSuccessfully(val musicianName: String) : AddMusiciansEvent
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailUiState.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Band
+
+sealed interface BandDetailUiState {
+    data object Loading : BandDetailUiState
+    data class Success(val band: Band) : BandDetailUiState
+    data object NotFound : BandDetailUiState
+    data class Error(val isNetworkError: Boolean) : BandDetailUiState
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModel.kt
@@ -1,0 +1,51 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class BandDetailViewModel @Inject constructor(
+    private val getBandDetail: GetBandDetailUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BandDetailUiState>(BandDetailUiState.Loading)
+    val uiState: StateFlow<BandDetailUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+    private var currentId: Int? = null
+
+    fun loadBand(id: Int) {
+        currentId = id
+        loadJob?.cancel()
+        _uiState.value = BandDetailUiState.Loading
+        loadJob = viewModelScope.launch {
+            _uiState.value = try {
+                BandDetailUiState.Success(getBandDetail(id))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HttpException) {
+                if (e.code() == 404) BandDetailUiState.NotFound
+                else BandDetailUiState.Error(isNetworkError = false)
+            } catch (e: IOException) {
+                BandDetailUiState.Error(isNetworkError = true)
+            } catch (e: Exception) {
+                BandDetailUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+
+    fun retry() {
+        currentId?.let { loadBand(it) }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListUiState.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.BandSummary
+
+sealed interface BandListUiState {
+    data object Loading : BandListUiState
+    data class Success(val bands: List<BandSummary>) : BandListUiState
+    data object Empty : BandListUiState
+    data class Error(val isNetworkError: Boolean) : BandListUiState
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModel.kt
@@ -1,0 +1,46 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.GetBandsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class BandListViewModel @Inject constructor(
+    private val getBands: GetBandsUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BandListUiState>(BandListUiState.Loading)
+    val uiState: StateFlow<BandListUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun retry() { load() }
+
+    private fun load() {
+        _uiState.value = BandListUiState.Loading
+        viewModelScope.launch {
+            _uiState.value = try {
+                val bands = getBands()
+                if (bands.isEmpty()) BandListUiState.Empty
+                else BandListUiState.Success(bands)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                BandListUiState.Error(isNetworkError = true)
+            } catch (e: HttpException) {
+                BandListUiState.Error(isNetworkError = false)
+            } catch (e: Exception) {
+                BandListUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,4 +134,45 @@
     <string name="add_comment_error_rating">Selecciona una calificación de 1 a 5</string>
     <string name="add_comment_error_network">Sin conexión. Intenta de nuevo.</string>
     <string name="add_comment_error_server">No pudimos publicar tu comentario. Inténtalo de nuevo.</string>
+
+    <!-- HU012 - Bandas -->
+    <string name="artists_tab_musicians">Músicos</string>
+    <string name="artists_tab_bands">Bandas</string>
+    <string name="bands_title">Bandas</string>
+    <string name="band_badge">BANDA</string>
+    <string name="band_detail_title">Detalle de la banda</string>
+    <string name="band_not_found_title">Banda no encontrada</string>
+    <string name="band_not_found_body">La banda solicitada no existe en el catálogo.</string>
+    <string name="band_members_section_title">Integrantes</string>
+    <string name="band_members_empty_title">Aún no hay integrantes</string>
+    <string name="band_members_empty_body">Esta banda todavía no tiene integrantes registrados.</string>
+    <string name="add_first_member_cta">Agregar primer integrante</string>
+    <string name="add_musicians_cta">Agregar músicos</string>
+    <string name="band_albums_section_title">Álbumes</string>
+    <plurals name="members_record_count">
+        <item quantity="one">%d integrante</item>
+        <item quantity="other">%d integrantes</item>
+    </plurals>
+    <plurals name="bands_record_count">
+        <item quantity="one">%d banda · orden alfa</item>
+        <item quantity="other">%d bandas · orden alfa</item>
+    </plurals>
+    <string name="search_placeholder_bands">¿Qué banda buscas?</string>
+
+    <!-- HU012 - Agregar músicos -->
+    <string name="add_musicians_title">Agregar músicos</string>
+    <string name="add_musicians_available_section">Músicos disponibles</string>
+    <string name="add_musicians_current_section">Integrantes actuales</string>
+    <string name="add_musicians_empty_filter">No se encontraron músicos con ese nombre</string>
+    <string name="add_musicians_empty_catalog">No hay músicos disponibles para agregar</string>
+    <string name="search_musicians_placeholder">Buscar por nombre</string>
+    <string name="add_musician_success">«%s» fue agregado a la banda</string>
+    <string name="add_musician_error_network">Sin conexión. Intenta de nuevo.</string>
+    <string name="add_musician_error_server">No pudimos agregar el músico. Inténtalo de nuevo.</string>
+
+    <!-- HU012 - Content descriptions -->
+    <string name="cd_band_image">Imagen de la banda</string>
+    <string name="cd_band_image_of">Imagen de la banda %s</string>
+    <string name="cd_add_musician_to_band">Agregar %s a la banda</string>
+    <string name="cd_adding_musician">Agregando músico</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,12 +87,8 @@
     <string name="cd_album_cover_of">Carátula del álbum %s</string>
     <string name="cd_menu">Menú</string>
     <string name="cd_profile">Perfil</string>
-    <string name="cd_open_album">Abrir álbum</string>
-    <string name="cd_artist_image">Foto del artista</string>
     <string name="cd_artist_photo_of">Foto del artista %s</string>
-    <string name="cd_open_artist">Abrir artista</string>
     <string name="cd_collector_avatar">Avatar del coleccionista</string>
-    <string name="cd_open_collector">Abrir coleccionista</string>
     <string name="cd_collector_email">Correo: %s</string>
     <string name="cd_collector_phone">Teléfono: %s</string>
     <string name="cd_track_with_duration">Pista %1$d, %2$s, duración %3$s</string>
@@ -101,7 +97,6 @@
     <string name="cd_rate_with_stars">Calificar con %1$d de 5 estrellas</string>
     <string name="cd_state_selected">Seleccionada</string>
     <string name="cd_state_not_selected">No seleccionada</string>
-    <string name="cd_state_loading">Cargando, por favor espera</string>
     <string name="cd_search_field">Campo de búsqueda: %s</string>
 
     <!-- List counters -->
@@ -137,7 +132,6 @@
     <!-- HU012 - Bandas -->
     <string name="artists_tab_musicians">Músicos</string>
     <string name="artists_tab_bands">Bandas</string>
-    <string name="bands_title">Bandas</string>
     <string name="band_badge">BANDA</string>
     <string name="band_detail_title">Detalle de la banda</string>
     <string name="band_not_found_title">Banda no encontrada</string>
@@ -163,14 +157,12 @@
     <string name="add_musicians_available_section">Músicos disponibles</string>
     <string name="add_musicians_current_section">Integrantes actuales</string>
     <string name="add_musicians_empty_filter">No se encontraron músicos con ese nombre</string>
-    <string name="add_musicians_empty_catalog">No hay músicos disponibles para agregar</string>
     <string name="search_musicians_placeholder">Buscar por nombre</string>
     <string name="add_musician_success">«%s» fue agregado a la banda</string>
     <string name="add_musician_error_network">Sin conexión. Intenta de nuevo.</string>
     <string name="add_musician_error_server">No pudimos agregar el músico. Inténtalo de nuevo.</string>
 
     <!-- HU012 - Content descriptions -->
-    <string name="cd_band_image">Imagen de la banda</string>
     <string name="cd_band_image_of">Imagen de la banda %s</string>
     <string name="cd_add_musician_to_band">Agregar %s a la banda</string>
     <string name="cd_adding_musician">Agregando músico</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,6 @@
     <string name="add_comment_submit">Publicar comentario</string>
     <string name="add_comment_action_cta">+ Comentar</string>
     <string name="add_comment_error_description">El comentario no puede estar vacío</string>
-    <string name="add_comment_error_rating">Selecciona una calificación de 1 a 5</string>
     <string name="add_comment_error_network">Sin conexión. Intenta de nuevo.</string>
     <string name="add_comment_error_server">No pudimos publicar tu comentario. Inténtalo de nuevo.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,13 +84,25 @@
 
     <!-- Content descriptions -->
     <string name="cd_album_cover">Portada del álbum</string>
+    <string name="cd_album_cover_of">Carátula del álbum %s</string>
     <string name="cd_menu">Menú</string>
     <string name="cd_profile">Perfil</string>
     <string name="cd_open_album">Abrir álbum</string>
     <string name="cd_artist_image">Foto del artista</string>
+    <string name="cd_artist_photo_of">Foto del artista %s</string>
     <string name="cd_open_artist">Abrir artista</string>
     <string name="cd_collector_avatar">Avatar del coleccionista</string>
     <string name="cd_open_collector">Abrir coleccionista</string>
+    <string name="cd_collector_email">Correo: %s</string>
+    <string name="cd_collector_phone">Teléfono: %s</string>
+    <string name="cd_track_with_duration">Pista %1$d, %2$s, duración %3$s</string>
+    <string name="cd_track_no_duration">Pista %1$d, %2$s</string>
+    <string name="cd_rating_summary">Calificación %1$d de 5</string>
+    <string name="cd_rate_with_stars">Calificar con %1$d de 5 estrellas</string>
+    <string name="cd_state_selected">Seleccionada</string>
+    <string name="cd_state_not_selected">No seleccionada</string>
+    <string name="cd_state_loading">Cargando, por favor espera</string>
+    <string name="cd_search_field">Campo de búsqueda: %s</string>
 
     <!-- List counters -->
     <plurals name="albums_record_count">

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt
@@ -1,0 +1,173 @@
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.BandDao
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
+import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class BandRepositoryImplTest {
+
+    private val api: VinilosApiService = mockk()
+    private val dao: BandDao = mockk(relaxed = true)
+    private val repo = BandRepositoryImpl(api, dao)
+
+    @Test
+    fun `getBands network success caches and returns mapped list`() = runTest {
+        coEvery { api.getBands() } returns listOf(
+            BandDto(1, "Queen", "img1", "desc", "1970-01-01"),
+            BandDto(2, "Aerosmith", "img2", "desc", "1970-01-01"),
+        )
+
+        val result = repo.getBands()
+
+        assertEquals(2, result.size)
+        assertEquals("Queen", result[0].name)
+        coVerify { dao.replaceBands(any()) }
+    }
+
+    @Test
+    fun `getBands IOException returns cache when populated`() = runTest {
+        coEvery { api.getBands() } throws IOException("offline")
+        coEvery { dao.getAll() } returns listOf(BandListEntity(1, "Queen", ""))
+
+        val result = repo.getBands()
+
+        assertEquals(1, result.size)
+        assertEquals("Queen", result[0].name)
+    }
+
+    @Test
+    fun `getBands IOException rethrows when cache empty`() = runTest {
+        coEvery { api.getBands() } throws IOException("offline")
+        coEvery { dao.getAll() } returns emptyList()
+
+        try {
+            repo.getBands()
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue(true)
+        }
+    }
+
+    @Test
+    fun `getBands HttpException propagates`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType()))
+        )
+        coEvery { api.getBands() } throws httpError
+
+        try {
+            repo.getBands()
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            assertEquals(500, e.code())
+        }
+    }
+
+    @Test
+    fun `getBandDetail success upserts and returns mapped band`() = runTest {
+        coEvery { api.getBandDetail(1) } returns BandDetailDto(
+            id = 1,
+            name = "Queen",
+            image = "img",
+            description = "desc",
+            creationDate = "1970-01-01",
+            musicians = listOf(
+                MusicianDetailDto(10, "Freddie", "img-f", "", "1946-09-05", emptyList(), emptyList())
+            ),
+            albums = listOf(
+                AlbumDto(100L, "A Night at the Opera", "cover", "1975-01-01", null, "Rock", null, null, null, null)
+            ),
+        )
+
+        val result = repo.getBandDetail(1)
+
+        assertEquals("Queen", result.name)
+        assertEquals(1, result.members.size)
+        assertEquals("Freddie", result.members[0].name)
+        coVerify { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `getBandDetail IOException returns cache when available`() = runTest {
+        coEvery { api.getBandDetail(1) } throws IOException("offline")
+        coEvery { dao.getDetailById(1) } returns BandDetailEntity(
+            id = 1, name = "Queen", image = "", description = "", creationDate = "",
+            members = emptyList(), albums = emptyList(),
+        )
+
+        val result = repo.getBandDetail(1)
+        assertEquals("Queen", result.name)
+    }
+
+    @Test
+    fun `getBandDetail IOException rethrows when no cache`() = runTest {
+        coEvery { api.getBandDetail(1) } throws IOException("offline")
+        coEvery { dao.getDetailById(1) } returns null
+
+        try {
+            repo.getBandDetail(1)
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue(true)
+        }
+    }
+
+    @Test
+    fun `addMusicianToBand success write-through updates cached detail`() = runTest {
+        val cachedBand = BandDetailEntity(
+            id = 1, name = "Queen", image = "", description = "", creationDate = "",
+            members = emptyList(), albums = emptyList(),
+        )
+        coEvery { dao.getDetailById(1) } returns cachedBand
+        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+        coEvery { api.getMusicianDetail(10) } returns MusicianDetailDto(
+            10, "Freddie", "img", "", "1946-09-05", emptyList(), emptyList()
+        )
+
+        repo.addMusicianToBand(1, 10)
+
+        coVerify {
+            dao.upsertDetail(match { it.members.size == 1 && it.members[0].name == "Freddie" })
+        }
+    }
+
+    @Test
+    fun `addMusicianToBand without cache only posts and skips local update`() = runTest {
+        coEvery { dao.getDetailById(1) } returns null
+        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+
+        repo.addMusicianToBand(1, 10)
+
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `addMusicianToBand IOException rethrows leaving cache intact`() = runTest {
+        coEvery { api.addMusicianToBand(1, 10) } throws IOException("offline")
+
+        try {
+            repo.addMusicianToBand(1, 10)
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            coVerify(exactly = 0) { dao.upsertDetail(any()) }
+        }
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt
@@ -137,7 +137,7 @@ class BandRepositoryImplTest {
             members = emptyList(), albums = emptyList(),
         )
         coEvery { dao.getDetailById(1) } returns cachedBand
-        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+        coEvery { api.addMusicianToBand(1, 10) } returns Unit
         coEvery { api.getMusicianDetail(10) } returns MusicianDetailDto(
             10, "Freddie", "img", "", "1946-09-05", emptyList(), emptyList()
         )
@@ -152,7 +152,7 @@ class BandRepositoryImplTest {
     @Test
     fun `addMusicianToBand without cache only posts and skips local update`() = runTest {
         coEvery { dao.getDetailById(1) } returns null
-        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+        coEvery { api.addMusicianToBand(1, 10) } returns Unit
 
         repo.addMusicianToBand(1, 10)
 
@@ -163,11 +163,31 @@ class BandRepositoryImplTest {
     fun `addMusicianToBand IOException rethrows leaving cache intact`() = runTest {
         coEvery { api.addMusicianToBand(1, 10) } throws IOException("offline")
 
+        var threw = false
         try {
             repo.addMusicianToBand(1, 10)
-            fail("Expected IOException")
         } catch (e: IOException) {
-            coVerify(exactly = 0) { dao.upsertDetail(any()) }
+            threw = true
         }
+        assertTrue("Expected IOException", threw)
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `addMusicianToBand HttpException propagates and skips cache update`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(409, "".toResponseBody("text/plain".toMediaType()))
+        )
+        coEvery { api.addMusicianToBand(1, 10) } throws httpError
+
+        var threw = false
+        try {
+            repo.addMusicianToBand(1, 10)
+        } catch (e: HttpException) {
+            threw = true
+            assertEquals(409, e.code())
+        }
+        assertTrue("Expected HttpException", threw)
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
     }
 }

--- a/app/src/test/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCaseTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCaseTest.kt
@@ -1,0 +1,23 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AddMusicianToBandUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = AddMusicianToBandUseCase(repo)
+
+    @Test
+    fun `invoke delegates bandId and musicianId to repository`() = runTest {
+        coEvery { repo.addMusicianToBand(1, 10) } returns Unit
+
+        useCase(bandId = 1, musicianId = 10)
+
+        coVerify(exactly = 1) { repo.addMusicianToBand(1, 10) }
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCaseTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCaseTest.kt
@@ -1,0 +1,30 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetBandDetailUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = GetBandDetailUseCase(repo)
+
+    @Test
+    fun `invoke delegates to repository getBandDetail with id`() = runTest {
+        val expected = Band(
+            id = 1, name = "Queen", image = "img", description = "desc",
+            creationDate = "1970-01-01", members = emptyList(), albums = emptyList(),
+        )
+        coEvery { repo.getBandDetail(1) } returns expected
+
+        val result = useCase(1)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { repo.getBandDetail(1) }
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCaseTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetBandsUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = GetBandsUseCase(repo)
+
+    @Test
+    fun `invoke delegates to repository getBands`() = runTest {
+        val expected = listOf(BandSummary(1, "Queen", "img"))
+        coEvery { repo.getBands() } returns expected
+
+        val result = useCase()
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { repo.getBands() }
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddCommentViewModelTest.kt
@@ -114,26 +114,35 @@ class AddCommentViewModelTest {
 
         val form = viewModel.form.value
         assertEquals(FormError.EmptyDescription, form.descriptionError)
-        assertEquals(null, form.ratingError)
         assertEquals(AddCommentUiState.Idle, viewModel.uiState.value)
         assertEquals(0, repo.callCount)
     }
 
     @Test
-    fun `submit with rating zero sets ratingError and does not call repo`() = runTest {
-        val repo = FakeAlbumRepository()
+    fun `submit with rating zero is accepted and reaches repo`() = runTest {
+        val repo = FakeAlbumRepository().apply {
+            addCommentResult = Result.success(
+                Comment(id = 7L, description = "Buen álbum", rating = 0),
+            )
+        }
         val viewModel = buildViewModel(repo)
         viewModel.onDescriptionChange("Buen álbum")
-        // rating left at 0
+        // rating left at 0 — backend permite 0..5
 
-        viewModel.submit()
-        advanceUntilIdle()
-
-        val form = viewModel.form.value
-        assertEquals(FormError.InvalidRating, form.ratingError)
-        assertEquals(null, form.descriptionError)
-        assertEquals(AddCommentUiState.Idle, viewModel.uiState.value)
-        assertEquals(0, repo.callCount)
+        viewModel.uiState.test {
+            assertEquals(AddCommentUiState.Idle, awaitItem())
+            viewModel.submit()
+            assertEquals(AddCommentUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is AddCommentUiState.Success)
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals(1, repo.callCount)
+        assertEquals(
+            AddCommentArgs(albumId = 42L, description = "Buen álbum", rating = 0, collectorId = 100),
+            repo.lastArgs,
+        )
     }
 
     @Test
@@ -190,21 +199,16 @@ class AddCommentViewModelTest {
     }
 
     @Test
-    fun `onDescriptionChange and onRatingChange clear their respective errors`() = runTest {
+    fun `onDescriptionChange clears descriptionError`() = runTest {
         val repo = FakeAlbumRepository()
         val viewModel = buildViewModel(repo)
-        viewModel.submit() // both errors triggered
+        viewModel.submit() // description error triggered
         advanceUntilIdle()
 
         assertNotNull(viewModel.form.value.descriptionError)
-        assertNotNull(viewModel.form.value.ratingError)
 
         viewModel.onDescriptionChange("now filled")
         assertEquals(null, viewModel.form.value.descriptionError)
-        assertNotNull(viewModel.form.value.ratingError)
-
-        viewModel.onRatingChange(4)
-        assertEquals(null, viewModel.form.value.ratingError)
     }
 
     @Test

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt
@@ -1,0 +1,209 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.model.Musician
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddMusiciansToBandViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeMusicianRepo : MusicianRepository {
+        var allMusicians: List<MusicianSummary> = emptyList()
+        override suspend fun getMusicians(): List<MusicianSummary> = allMusicians
+        override suspend fun getMusicianDetail(id: Int): Musician = error("not used")
+    }
+
+    private class FakeBandRepo : BandRepository {
+        var bandResult: Result<Band> = Result.success(sampleBand(emptyList()))
+        var addResult: Result<Unit> = Result.success(Unit)
+        var addCallCount = 0
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = bandResult.getOrThrow()
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+            addCallCount++
+            addResult.getOrThrow()
+        }
+    }
+
+    companion object {
+        fun sampleBand(members: List<MusicianSummary>) = Band(
+            id = 1, name = "Queen", image = "", description = "",
+            creationDate = "", members = members, albums = emptyList(),
+        )
+    }
+
+    private fun buildVm(
+        musicianRepo: FakeMusicianRepo,
+        bandRepo: FakeBandRepo,
+        bandId: Int = 1,
+    ): AddMusiciansToBandViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("bandId" to bandId))
+        return AddMusiciansToBandViewModel(
+            getMusicians = GetMusiciansUseCase(musicianRepo),
+            getBandDetail = GetBandDetailUseCase(bandRepo),
+            addMusicianToBand = AddMusicianToBandUseCase(bandRepo),
+            savedStateHandle = savedStateHandle,
+        )
+    }
+
+    @Test
+    fun `initial load fetches catalog and band, excludes existing members`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(
+                MusicianSummary(10, "Freddie Mercury", "", ""),
+                MusicianSummary(11, "Brian May", "", ""),
+                MusicianSummary(12, "John Deacon", "", ""),
+            )
+        }
+        val bandRepo = FakeBandRepo().apply {
+            bandResult = Result.success(sampleBand(listOf(MusicianSummary(10, "Freddie Mercury", "", ""))))
+        }
+        val vm = buildVm(musicianRepo, bandRepo)
+
+        vm.form.test {
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertEquals(3, state.allMusicians.size)
+            assertEquals(setOf(10), state.currentMemberIds)
+            assertEquals(2, state.filteredAvailable.size)
+            assertTrue(state.filteredAvailable.none { it.id == 10 })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `query change with debounce filters by normalized name`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(
+                MusicianSummary(10, "José Pérez", "", ""),
+                MusicianSummary(11, "Brian May", "", ""),
+            )
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onQueryChange("jose")
+        advanceTimeBy(299L)
+        assertEquals(2, vm.form.value.filteredAvailable.size)
+
+        advanceTimeBy(1L)
+        advanceUntilIdle()
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+        assertEquals("José Pérez", vm.form.value.filteredAvailable[0].name)
+    }
+
+    @Test
+    fun `query is case and diacritic insensitive`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "José Pérez", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onQueryChange("PEREZ")
+        advanceTimeBy(300L)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+    }
+
+    @Test
+    fun `add musician success transitions Adding to Ready and updates memberIds`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        assertEquals(AddMusiciansUiState.Ready, vm.uiState.value)
+        assertTrue(vm.form.value.currentMemberIds.contains(10))
+        assertEquals(0, vm.form.value.filteredAvailable.size)
+        assertEquals(1, bandRepo.addCallCount)
+    }
+
+    @Test
+    fun `add musician double tap ignores second call while Adding`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        assertEquals(1, bandRepo.addCallCount)
+    }
+
+    @Test
+    fun `add musician IOException emits network Error without mutating lists`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo().apply { addResult = Result.failure(IOException("x")) }
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is AddMusiciansUiState.Error)
+        assertTrue((state as AddMusiciansUiState.Error).isNetworkError)
+        assertEquals(10, state.musicianId)
+        assertFalse(vm.form.value.currentMemberIds.contains(10))
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+    }
+
+    @Test
+    fun `add musician HttpException emits non-network Error`() = runTest {
+        val http = HttpException(Response.error<Any>(409, "".toResponseBody("text/plain".toMediaType())))
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo().apply { addResult = Result.failure(http) }
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is AddMusiciansUiState.Error)
+        assertFalse((state as AddMusiciansUiState.Error).isNetworkError)
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BandDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeBandRepository : BandRepository {
+        var nextResult: Result<Band> = Result.success(sampleBand(1))
+        var callCount = 0
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band {
+            callCount++
+            return nextResult.getOrThrow()
+        }
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    companion object {
+        fun sampleBand(id: Int) = Band(
+            id = id, name = "Queen", image = "img", description = "desc",
+            creationDate = "1970-01-01", members = emptyList(), albums = emptyList(),
+        )
+    }
+
+    private fun buildVm(repo: FakeBandRepository) = BandDetailViewModel(GetBandDetailUseCase(repo))
+
+    @Test
+    fun `loadBand emits Loading then Success`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(sampleBand(1)) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is BandDetailUiState.Success)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `loadBand with 404 emits NotFound`() = runTest {
+        val http404 = HttpException(Response.error<Any>(404, "".toResponseBody("text/plain".toMediaType())))
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(http404) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertEquals(BandDetailUiState.NotFound, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `loadBand with IOException emits network Error`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertEquals(BandDetailUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry re-invokes use case with last id`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.loadBand(42)
+        advanceUntilIdle()
+        repo.nextResult = Result.success(sampleBand(42))
+        vm.retry()
+        advanceUntilIdle()
+
+        assertEquals(2, repo.callCount)
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModelTest.kt
@@ -1,0 +1,121 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandsUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BandListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeBandRepository : BandRepository {
+        var nextResult: Result<List<BandSummary>> = Result.success(emptyList())
+        var callCount = 0
+        override suspend fun getBands(): List<BandSummary> {
+            callCount++
+            return nextResult.getOrThrow()
+        }
+        override suspend fun getBandDetail(id: Int): Band = error("not used")
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    private fun buildVm(repo: FakeBandRepository) = BandListViewModel(GetBandsUseCase(repo))
+
+    private fun sampleBands() = listOf(
+        BandSummary(1, "Queen", "img"),
+        BandSummary(2, "Aerosmith", "img"),
+    )
+
+    @Test
+    fun `emits Loading then Success when bands returned`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(sampleBands()) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is BandListUiState.Success)
+            assertEquals(2, (state as BandListUiState.Success).bands.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits Empty when list empty`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(emptyList()) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits network Error on IOException`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits server Error on HttpException`() = runTest {
+        val http = HttpException(Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType())))
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(http) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = false), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry re-invokes repository`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = true), awaitItem())
+
+            repo.nextResult = Result.success(sampleBands())
+            vm.retry()
+
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertTrue(awaitItem() is BandListUiState.Success)
+            assertEquals(2, repo.callCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-12-hu012-agregar-musicos-banda-plan.md
+++ b/docs/superpowers/plans/2026-05-12-hu012-agregar-musicos-banda-plan.md
@@ -1,0 +1,4171 @@
+# HU012 — Agregar músicos a una banda — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir a un coleccionista agregar músicos existentes a una banda del catálogo, manteniendo coherencia entre backend, caché local y UI.
+
+**Architecture:** Clean Architecture en tres capas (domain/data/presentation), MVVM con Jetpack Compose. `Band` se modela como entidad de dominio aislada (approach C tras resolver R7: existe ya `data class Performer` en `AlbumDetail.kt` con shape distinto). Patrón network-first + fallback a caché para lecturas; write-through cache para `addMusicianToBand`. Filtro de búsqueda local con debounce 300ms. Sub-tabs internas dentro de la tab "Artistas" (Músicos / Bandas).
+
+**Tech Stack:** Kotlin 2.0, Jetpack Compose, Hilt + KSP, Room (con bump a v5), Retrofit + Gson, Navigation Compose, Coil, Material 3. Tests: JUnit4 + MockK + Turbine + `kotlinx-coroutines-test` (JVM), Compose UI Test + Hilt Testing (instrumentados).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-12-hu012-agregar-musicos-banda-design.md`
+
+---
+
+## File Structure
+
+### Nuevos archivos
+
+**Domain (`app/src/main/java/com/misw4203/vinilos/domain/`):**
+- `model/BandSummary.kt` — modelo de lista
+- `model/Band.kt` — modelo de detalle
+- `repository/BandRepository.kt` — interfaz
+- `usecase/GetBandsUseCase.kt`
+- `usecase/GetBandDetailUseCase.kt`
+- `usecase/AddMusicianToBandUseCase.kt`
+
+**Data (`app/src/main/java/com/misw4203/vinilos/data/`):**
+- `remote/dto/BandDto.kt` — listado
+- `remote/dto/BandDetailDto.kt` — detalle (incluye `musicians: List<MusicianDetailDto>` y `albums: List<AlbumDto>`)
+- `local/entity/BandListEntity.kt`
+- `local/entity/BandDetailEntity.kt`
+- `local/dao/BandDao.kt`
+- `repository/BandRepositoryImpl.kt`
+
+**Presentation (`app/src/main/java/com/misw4203/vinilos/presentation/`):**
+- `viewmodel/BandListUiState.kt`
+- `viewmodel/BandListViewModel.kt`
+- `viewmodel/BandDetailUiState.kt` (incluye sealed `BandDetailUiState`)
+- `viewmodel/BandDetailViewModel.kt`
+- `viewmodel/AddMusiciansFormState.kt`
+- `viewmodel/AddMusiciansUiState.kt`
+- `viewmodel/AddMusiciansToBandViewModel.kt`
+- `ui/components/BandCard.kt`
+- `ui/components/MusicianRow.kt`
+- `ui/components/EmptyMembersState.kt`
+- `ui/components/PerformerHeader.kt`
+- `ui/screens/band/BandListContent.kt`
+- `ui/screens/band/BandDetailScreen.kt`
+- `ui/screens/band/AddMusiciansToBandScreen.kt`
+- `ui/screens/artist/ArtistsHubScreen.kt`
+- `ui/screens/artist/MusicianListContent.kt` (extraído de `MusicianListScreen.kt`)
+
+**Tests JVM (`app/src/test/`):**
+- `data/repository/BandRepositoryImplTest.kt`
+- `domain/usecase/GetBandsUseCaseTest.kt`
+- `domain/usecase/GetBandDetailUseCaseTest.kt`
+- `domain/usecase/AddMusicianToBandUseCaseTest.kt`
+- `presentation/viewmodel/BandListViewModelTest.kt`
+- `presentation/viewmodel/BandDetailViewModelTest.kt`
+- `presentation/viewmodel/AddMusiciansToBandViewModelTest.kt`
+
+**Tests instrumentados (`app/src/androidTest/`):**
+- `presentation/ui/components/BandCardTest.kt`
+- `presentation/ui/components/MusicianRowTest.kt`
+- `presentation/ui/components/EmptyMembersStateTest.kt`
+- `presentation/ui/screens/band/BandDetailScreenTest.kt`
+- `presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt`
+- `di/FakeBandRepository.kt`
+
+### Archivos a modificar
+
+- `app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt` — 4 endpoints nuevos
+- `app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt` — TypeConverter para `List<MusicianSummary>`
+- `app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt` — agregar entities + DAO, bump version a 5
+- `app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt` — provee `BandDao`
+- `app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt` — bind de `BandRepository`
+- `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt` — refactor → `MusicianListContent` (mismo archivo o nuevo)
+- `app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt` — nuevas rutas
+- `app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt` — registrar destinos + reemplazar `MusicianListScreen` por `ArtistsHubScreen`
+- `app/src/main/res/values/strings.xml` — strings nuevos
+- `app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt` — bind de fake `BandRepository`
+- `app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt` — caso E2E HU012
+
+---
+
+## Phase 1 — Domain models + DTOs (Commit 1 prep)
+
+### Task 1: `BandSummary` domain model
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/model/BandSummary.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.domain.model
+
+data class BandSummary(
+    val id: Int,
+    val name: String,
+    val image: String,
+)
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 2: `Band` domain model
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/model/Band.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.domain.model
+
+data class Band(
+    val id: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val creationDate: String,
+    val members: List<MusicianSummary>,
+    val albums: List<Album>,
+)
+```
+
+> Nota: `creationDate` reemplaza al `birthDate` de `Musician`. El backend devuelve `creationDate` para bandas.
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 3: `BandDto` y `BandDetailDto`
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDto.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDetailDto.kt`
+
+- [ ] **Step 1: Write `BandDto.kt`**
+
+```kotlin
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class BandDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("creationDate") val creationDate: String?,
+)
+```
+
+- [ ] **Step 2: Write `BandDetailDto.kt`**
+
+```kotlin
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class BandDetailDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("name") val name: String?,
+    @SerializedName("image") val image: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("creationDate") val creationDate: String?,
+    @SerializedName("musicians") val musicians: List<MusicianDetailDto>?,
+    @SerializedName("albums") val albums: List<AlbumDto>?,
+)
+```
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+## Phase 2 — Data local (Room entities, DAO, converters, database)
+
+### Task 4: `BandListEntity`
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/data/local/entity/BandListEntity.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.BandSummary
+
+@Entity(
+    tableName = "bands",
+    indices = [Index(value = ["name"])],
+)
+data class BandListEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+) {
+    fun toDomain() = BandSummary(
+        id = id,
+        name = name,
+        image = image,
+    )
+
+    companion object {
+        fun fromDomain(summary: BandSummary) = BandListEntity(
+            id = summary.id,
+            name = summary.name,
+            image = summary.image,
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 5: `BandDetailEntity` (con `members` y `albums` como JSON blob)
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/data/local/entity/BandDetailEntity.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+@Entity(tableName = "band_details")
+data class BandDetailEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val creationDate: String,
+    val members: List<MusicianSummary>,
+    val albums: List<Album>,
+) {
+    fun toDomain() = Band(
+        id = id,
+        name = name,
+        image = image,
+        description = description,
+        creationDate = creationDate,
+        members = members,
+        albums = albums,
+    )
+
+    companion object {
+        fun fromDomain(band: Band) = BandDetailEntity(
+            id = band.id,
+            name = band.name,
+            image = band.image,
+            description = band.description,
+            creationDate = band.creationDate,
+            members = band.members,
+            albums = band.albums,
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Compile (Room requirá nuevo TypeConverter — esperar warning/error)**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD FAILED — Room reporta missing TypeConverter para `List<MusicianSummary>` (se resuelve en Task 6).
+
+---
+
+### Task 6: TypeConverter para `List<MusicianSummary>` en `Converters`
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt`
+
+- [ ] **Step 1: Agregar import y dos TypeConverters**
+
+Añadir el import:
+
+```kotlin
+import com.misw4203.vinilos.domain.model.MusicianSummary
+```
+
+Agregar al final de la clase `Converters` (antes del `}` final):
+
+```kotlin
+    @TypeConverter
+    fun musicianSummariesToJson(value: List<MusicianSummary>): String = gson.toJson(value)
+
+    @TypeConverter
+    fun jsonToMusicianSummaries(value: String): List<MusicianSummary> =
+        gson.fromJson(value, object : TypeToken<List<MusicianSummary>>() {}.type)
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL (el error de Task 5 step 2 desaparece).
+
+---
+
+## Phase 3 — Data remote: API endpoints + Repository (TDD)
+
+### Task 10: Cuatro endpoints nuevos en `VinilosApiService`
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt`
+
+- [ ] **Step 1: Agregar imports**
+
+```kotlin
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
+import retrofit2.Response
+```
+
+- [ ] **Step 2: Agregar los cuatro endpoints antes del cierre de la interfaz**
+
+```kotlin
+    @GET("bands")
+    suspend fun getBands(): List<BandDto>
+
+    @GET("bands/{id}")
+    suspend fun getBandDetail(@Path("id") id: Int): BandDetailDto
+
+    @GET("bands/{id}/musicians")
+    suspend fun getBandMembers(@Path("id") id: Int): List<MusicianDetailDto>
+
+    @POST("bands/{bandId}/musicians/{musicianId}")
+    suspend fun addMusicianToBand(
+        @Path("bandId") bandId: Int,
+        @Path("musicianId") musicianId: Int,
+    ): Response<Unit>
+```
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 11: `BandRepository` interface (domain)
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/repository/BandRepository.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.domain.repository
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+
+interface BandRepository {
+    suspend fun getBands(): List<BandSummary>
+    suspend fun getBandDetail(id: Int): Band
+    suspend fun addMusicianToBand(bandId: Int, musicianId: Int)
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 12: `BandRepositoryImpl` con tests (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt`
+
+- [ ] **Step 1: Escribir el test failing primero**
+
+Crear `app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt`:
+
+```kotlin
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.BandDao
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
+import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+class BandRepositoryImplTest {
+
+    private val api: VinilosApiService = mockk()
+    private val dao: BandDao = mockk(relaxed = true)
+    private val repo = BandRepositoryImpl(api, dao)
+
+    @Test
+    fun `getBands network success caches and returns mapped list`() = runTest {
+        coEvery { api.getBands() } returns listOf(
+            BandDto(1, "Queen", "img1", "desc", "1970-01-01"),
+            BandDto(2, "Aerosmith", "img2", "desc", "1970-01-01"),
+        )
+
+        val result = repo.getBands()
+
+        assertEquals(2, result.size)
+        assertEquals("Queen", result[0].name)
+        coVerify { dao.replaceBands(any()) }
+    }
+
+    @Test
+    fun `getBands IOException returns cache when populated`() = runTest {
+        coEvery { api.getBands() } throws IOException("offline")
+        coEvery { dao.getAll() } returns listOf(BandListEntity(1, "Queen", ""))
+
+        val result = repo.getBands()
+
+        assertEquals(1, result.size)
+        assertEquals("Queen", result[0].name)
+    }
+
+    @Test
+    fun `getBands IOException rethrows when cache empty`() = runTest {
+        coEvery { api.getBands() } throws IOException("offline")
+        coEvery { dao.getAll() } returns emptyList()
+
+        try {
+            repo.getBands()
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue(true)
+        }
+    }
+
+    @Test
+    fun `getBands HttpException propagates`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType()))
+        )
+        coEvery { api.getBands() } throws httpError
+
+        try {
+            repo.getBands()
+            fail("Expected HttpException")
+        } catch (e: HttpException) {
+            assertEquals(500, e.code())
+        }
+    }
+
+    @Test
+    fun `getBandDetail success upserts and returns mapped band`() = runTest {
+        coEvery { api.getBandDetail(1) } returns BandDetailDto(
+            id = 1,
+            name = "Queen",
+            image = "img",
+            description = "desc",
+            creationDate = "1970-01-01",
+            musicians = listOf(
+                MusicianDetailDto(10, "Freddie", "img-f", "", "1946-09-05", emptyList(), emptyList())
+            ),
+            albums = listOf(
+                AlbumDto(100, "A Night at the Opera", "cover", "1975-01-01", null, "Rock", null, null, null, null)
+            ),
+        )
+
+        val result = repo.getBandDetail(1)
+
+        assertEquals("Queen", result.name)
+        assertEquals(1, result.members.size)
+        assertEquals("Freddie", result.members[0].name)
+        coVerify { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `getBandDetail IOException returns cache when available`() = runTest {
+        coEvery { api.getBandDetail(1) } throws IOException("offline")
+        coEvery { dao.getDetailById(1) } returns BandDetailEntity(
+            id = 1, name = "Queen", image = "", description = "", creationDate = "",
+            members = emptyList(), albums = emptyList(),
+        )
+
+        val result = repo.getBandDetail(1)
+        assertEquals("Queen", result.name)
+    }
+
+    @Test
+    fun `getBandDetail IOException rethrows when no cache`() = runTest {
+        coEvery { api.getBandDetail(1) } throws IOException("offline")
+        coEvery { dao.getDetailById(1) } returns null
+
+        try {
+            repo.getBandDetail(1)
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue(true)
+        }
+    }
+
+    @Test
+    fun `addMusicianToBand success write-through updates cached detail`() = runTest {
+        val cachedBand = BandDetailEntity(
+            id = 1, name = "Queen", image = "", description = "", creationDate = "",
+            members = emptyList(), albums = emptyList(),
+        )
+        coEvery { dao.getDetailById(1) } returns cachedBand
+        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+        coEvery { api.getMusicianDetail(10) } returns MusicianDetailDto(
+            10, "Freddie", "img", "", "1946-09-05", emptyList(), emptyList()
+        )
+
+        repo.addMusicianToBand(1, 10)
+
+        coVerify {
+            dao.upsertDetail(match { it.members.size == 1 && it.members[0].name == "Freddie" })
+        }
+    }
+
+    @Test
+    fun `addMusicianToBand without cache only posts and skips local update`() = runTest {
+        coEvery { dao.getDetailById(1) } returns null
+        coEvery { api.addMusicianToBand(1, 10) } returns Response.success(Unit)
+
+        repo.addMusicianToBand(1, 10)
+
+        coVerify(exactly = 0) { dao.upsertDetail(any()) }
+    }
+
+    @Test
+    fun `addMusicianToBand IOException rethrows leaving cache intact`() = runTest {
+        coEvery { api.addMusicianToBand(1, 10) } throws IOException("offline")
+
+        try {
+            repo.addMusicianToBand(1, 10)
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            coVerify(exactly = 0) { dao.upsertDetail(any()) }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test (debe fallar — la clase no existe aún)**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.data.repository.BandRepositoryImplTest"`
+Expected: Compilation FAIL — `Unresolved reference: BandRepositoryImpl`.
+
+- [ ] **Step 3: Crear `BandRepositoryImpl`**
+
+`app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt`:
+
+```kotlin
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.local.dao.BandDao
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.AlbumDto
+import com.misw4203.vinilos.data.remote.dto.BandDetailDto
+import com.misw4203.vinilos.data.remote.dto.BandDto
+import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import javax.inject.Inject
+
+class BandRepositoryImpl @Inject constructor(
+    private val api: VinilosApiService,
+    private val dao: BandDao,
+) : BandRepository {
+
+    override suspend fun getBands(): List<BandSummary> = withContext(Dispatchers.IO) {
+        try {
+            val summaries = api.getBands().map { it.toSummary() }
+            dao.replaceBands(summaries.map { BandListEntity.fromDomain(it) })
+            summaries
+        } catch (e: IOException) {
+            val cached = dao.getAll()
+            if (cached.isNotEmpty()) cached.map { it.toDomain() } else throw e
+        }
+    }
+
+    override suspend fun getBandDetail(id: Int): Band = withContext(Dispatchers.IO) {
+        try {
+            val dto = api.getBandDetail(id)
+            val band = dto.toDomain()
+            dao.upsertDetail(BandDetailEntity.fromDomain(band))
+            band
+        } catch (e: IOException) {
+            dao.getDetailById(id)?.toDomain() ?: throw e
+        }
+    }
+
+    override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = withContext(Dispatchers.IO) {
+        api.addMusicianToBand(bandId, musicianId)
+        // Write-through: si el detalle está cacheado, agregamos el nuevo miembro.
+        val cached = dao.getDetailById(bandId)
+        if (cached != null) {
+            val musicianDto = api.getMusicianDetail(musicianId)
+            val newMember = MusicianSummary(
+                id = musicianDto.id,
+                name = musicianDto.name,
+                image = musicianDto.image,
+                birthDate = musicianDto.birthDate,
+            )
+            val updated = cached.copy(members = cached.members + newMember)
+            dao.upsertDetail(updated)
+        }
+        Unit
+    }
+
+    private fun BandDto.toSummary() = BandSummary(
+        id = id,
+        name = name.orEmpty(),
+        image = image.orEmpty(),
+    )
+
+    private fun BandDetailDto.toDomain() = Band(
+        id = id,
+        name = name.orEmpty(),
+        image = image.orEmpty(),
+        description = description.orEmpty(),
+        creationDate = creationDate.orEmpty(),
+        members = musicians.orEmpty().map {
+            MusicianSummary(it.id, it.name, it.image, it.birthDate)
+        },
+        albums = albums.orEmpty().map { it.toDomain() },
+    )
+
+    private fun AlbumDto.toDomain() = Album(
+        id = id,
+        name = name.orEmpty(),
+        coverUrl = cover.orEmpty(),
+        artistName = performers?.firstOrNull()?.name.orEmpty(),
+        releaseYear = releaseDate?.take(4).orEmpty(),
+        genre = genre.orEmpty(),
+    )
+}
+```
+
+- [ ] **Step 4: Run tests para verificar que pasan**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.data.repository.BandRepositoryImplTest"`
+Expected: 10 tests PASS.
+
+---
+
+### Task 13: Binding en `RepositoryModule`
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt`
+
+- [ ] **Step 1: Agregar imports**
+
+```kotlin
+import com.misw4203.vinilos.data.repository.BandRepositoryImpl
+import com.misw4203.vinilos.domain.repository.BandRepository
+```
+
+- [ ] **Step 2: Agregar binding antes del cierre de la clase**
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindBandRepository(impl: BandRepositoryImpl): BandRepository
+```
+
+- [ ] **Step 3: Verify compiles + Hilt resuelve dependencias**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit fase 1**
+
+```bash
+git add app/src/main/java/com/misw4203/vinilos/domain/model/BandSummary.kt \
+        app/src/main/java/com/misw4203/vinilos/domain/model/Band.kt \
+        app/src/main/java/com/misw4203/vinilos/domain/repository/BandRepository.kt \
+        app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDto.kt \
+        app/src/main/java/com/misw4203/vinilos/data/remote/dto/BandDetailDto.kt \
+        app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt \
+        app/src/main/java/com/misw4203/vinilos/data/local/entity/BandListEntity.kt \
+        app/src/main/java/com/misw4203/vinilos/data/local/entity/BandDetailEntity.kt \
+        app/src/main/java/com/misw4203/vinilos/data/local/dao/BandDao.kt \
+        app/src/main/java/com/misw4203/vinilos/data/local/converter/Converters.kt \
+        app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt \
+        app/src/main/java/com/misw4203/vinilos/data/repository/BandRepositoryImpl.kt \
+        app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt \
+        app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt \
+        app/src/test/java/com/misw4203/vinilos/data/repository/BandRepositoryImplTest.kt
+
+git commit -m "$(cat <<'EOF'
+feat(hu012): Se agregan dominio, DTOs, entidades, DAO y repositorio de Bandas
+
+- Domain: Band, BandSummary, BandRepository
+- DTOs: BandDto, BandDetailDto
+- Room: BandListEntity, BandDetailEntity, BandDao + TypeConverter para
+  List<MusicianSummary>. VinilosDatabase v5.
+- API: 4 endpoints nuevos (/bands, /bands/{id}, /bands/{id}/musicians,
+  POST /bands/{bandId}/musicians/{musicianId}).
+- Repository network-first + fallback a caché; write-through cache en
+  addMusicianToBand (re-fetch del músico para extender members).
+- Hilt binding en RepositoryModule.
+- 10 tests unitarios sobre BandRepositoryImpl cubriendo éxito, IOException,
+  HttpException, cache hit/miss y write-through.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4 — UseCases + tests
+
+### Task 14: `GetBandsUseCase` con test (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCaseTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCase.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetBandsUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = GetBandsUseCase(repo)
+
+    @Test
+    fun `invoke delegates to repository getBands`() = runTest {
+        val expected = listOf(BandSummary(1, "Queen", "img"))
+        coEvery { repo.getBands() } returns expected
+
+        val result = useCase()
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { repo.getBands() }
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.GetBandsUseCaseTest"`
+Expected: Compilation FAIL — `Unresolved reference: GetBandsUseCase`.
+
+- [ ] **Step 3: Crear el use case**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class GetBandsUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(): List<BandSummary> = repository.getBands()
+}
+```
+
+- [ ] **Step 4: Run test y verificar que pasa**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.GetBandsUseCaseTest"`
+Expected: 1 test PASS.
+
+---
+
+### Task 15: `GetBandDetailUseCase` con test (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCaseTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCase.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GetBandDetailUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = GetBandDetailUseCase(repo)
+
+    @Test
+    fun `invoke delegates to repository getBandDetail with id`() = runTest {
+        val expected = Band(
+            id = 1, name = "Queen", image = "img", description = "desc",
+            creationDate = "1970-01-01", members = emptyList(), albums = emptyList(),
+        )
+        coEvery { repo.getBandDetail(1) } returns expected
+
+        val result = useCase(1)
+
+        assertEquals(expected, result)
+        coVerify(exactly = 1) { repo.getBandDetail(1) }
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.GetBandDetailUseCaseTest"`
+Expected: Compilation FAIL.
+
+- [ ] **Step 3: Crear el use case**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class GetBandDetailUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(bandId: Int): Band = repository.getBandDetail(bandId)
+}
+```
+
+- [ ] **Step 4: Run y verificar que pasa**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.GetBandDetailUseCaseTest"`
+Expected: 1 test PASS.
+
+---
+
+### Task 16: `AddMusicianToBandUseCase` con test (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCaseTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCase.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.repository.BandRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AddMusicianToBandUseCaseTest {
+
+    private val repo: BandRepository = mockk()
+    private val useCase = AddMusicianToBandUseCase(repo)
+
+    @Test
+    fun `invoke delegates bandId and musicianId to repository`() = runTest {
+        coEvery { repo.addMusicianToBand(1, 10) } returns Unit
+
+        useCase(bandId = 1, musicianId = 10)
+
+        coVerify(exactly = 1) { repo.addMusicianToBand(1, 10) }
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCaseTest"`
+Expected: Compilation FAIL.
+
+- [ ] **Step 3: Crear el use case**
+
+```kotlin
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+
+class AddMusicianToBandUseCase @Inject constructor(
+    private val repository: BandRepository,
+) {
+    suspend operator fun invoke(bandId: Int, musicianId: Int) =
+        repository.addMusicianToBand(bandId, musicianId)
+}
+```
+
+- [ ] **Step 4: Run y verificar que pasa**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCaseTest"`
+Expected: 1 test PASS.
+
+---
+
+## Phase 5 — ViewModels + tests (Commit 2)
+
+### Task 17: `BandListUiState` + `BandListViewModel` con tests (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModelTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListUiState.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModel.kt`
+
+- [ ] **Step 1: Crear `BandListUiState.kt`** (la sealed la creamos primero porque el test la referencia)
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.BandSummary
+
+sealed interface BandListUiState {
+    data object Loading : BandListUiState
+    data class Success(val bands: List<BandSummary>) : BandListUiState
+    data object Empty : BandListUiState
+    data class Error(val isNetworkError: Boolean) : BandListUiState
+}
+```
+
+- [ ] **Step 2: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandsUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BandListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeBandRepository : BandRepository {
+        var nextResult: Result<List<BandSummary>> = Result.success(emptyList())
+        var callCount = 0
+        override suspend fun getBands(): List<BandSummary> {
+            callCount++
+            return nextResult.getOrThrow()
+        }
+        override suspend fun getBandDetail(id: Int): Band = error("not used")
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    private fun buildVm(repo: FakeBandRepository) = BandListViewModel(GetBandsUseCase(repo))
+
+    private fun sampleBands() = listOf(
+        BandSummary(1, "Queen", "img"),
+        BandSummary(2, "Aerosmith", "img"),
+    )
+
+    @Test
+    fun `emits Loading then Success when bands returned`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(sampleBands()) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is BandListUiState.Success)
+            assertEquals(2, (state as BandListUiState.Success).bands.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits Empty when list empty`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(emptyList()) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits network Error on IOException`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits server Error on HttpException`() = runTest {
+        val http = HttpException(Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType())))
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(http) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = false), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry re-invokes repository`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(BandListUiState.Error(isNetworkError = true), awaitItem())
+
+            repo.nextResult = Result.success(sampleBands())
+            vm.retry()
+
+            assertEquals(BandListUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertTrue(awaitItem() is BandListUiState.Success)
+            assertEquals(2, repo.callCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.BandListViewModelTest"`
+Expected: Compilation FAIL — `Unresolved reference: BandListViewModel`.
+
+- [ ] **Step 4: Crear el ViewModel**
+
+`app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModel.kt`:
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.GetBandsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class BandListViewModel @Inject constructor(
+    private val getBands: GetBandsUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BandListUiState>(BandListUiState.Loading)
+    val uiState: StateFlow<BandListUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun retry() { load() }
+
+    private fun load() {
+        _uiState.value = BandListUiState.Loading
+        viewModelScope.launch {
+            _uiState.value = try {
+                val bands = getBands()
+                if (bands.isEmpty()) BandListUiState.Empty
+                else BandListUiState.Success(bands)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                BandListUiState.Error(isNetworkError = true)
+            } catch (e: HttpException) {
+                BandListUiState.Error(isNetworkError = false)
+            } catch (e: Exception) {
+                BandListUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.BandListViewModelTest"`
+Expected: 5 tests PASS.
+
+---
+
+### Task 18: `BandDetailUiState` + `BandDetailViewModel` con tests (TDD)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModelTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailUiState.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModel.kt`
+
+- [ ] **Step 1: Crear `BandDetailUiState.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Band
+
+sealed interface BandDetailUiState {
+    data object Loading : BandDetailUiState
+    data class Success(val band: Band) : BandDetailUiState
+    data object NotFound : BandDetailUiState
+    data class Error(val isNetworkError: Boolean) : BandDetailUiState
+}
+```
+
+- [ ] **Step 2: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BandDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeBandRepository : BandRepository {
+        var nextResult: Result<Band> = Result.success(sampleBand(1))
+        var callCount = 0
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band {
+            callCount++
+            return nextResult.getOrThrow()
+        }
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    companion object {
+        fun sampleBand(id: Int) = Band(
+            id = id, name = "Queen", image = "img", description = "desc",
+            creationDate = "1970-01-01", members = emptyList(), albums = emptyList(),
+        )
+    }
+
+    private fun buildVm(repo: FakeBandRepository) = BandDetailViewModel(GetBandDetailUseCase(repo))
+
+    @Test
+    fun `loadBand emits Loading then Success`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.success(sampleBand(1)) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is BandDetailUiState.Success)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `loadBand with 404 emits NotFound`() = runTest {
+        val http404 = HttpException(Response.error<Any>(404, "".toResponseBody("text/plain".toMediaType())))
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(http404) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertEquals(BandDetailUiState.NotFound, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `loadBand with IOException emits network Error`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.uiState.test {
+            assertEquals(BandDetailUiState.Loading, awaitItem())
+            vm.loadBand(1)
+            advanceUntilIdle()
+            assertEquals(BandDetailUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry re-invokes use case with last id`() = runTest {
+        val repo = FakeBandRepository().apply { nextResult = Result.failure(IOException("x")) }
+        val vm = buildVm(repo)
+
+        vm.loadBand(42)
+        advanceUntilIdle()
+        repo.nextResult = Result.success(sampleBand(42))
+        vm.retry()
+        advanceUntilIdle()
+
+        assertEquals(2, repo.callCount)
+    }
+}
+```
+
+- [ ] **Step 3: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModelTest"`
+Expected: Compilation FAIL.
+
+- [ ] **Step 4: Crear el ViewModel**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class BandDetailViewModel @Inject constructor(
+    private val getBandDetail: GetBandDetailUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BandDetailUiState>(BandDetailUiState.Loading)
+    val uiState: StateFlow<BandDetailUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+    private var currentId: Int? = null
+
+    fun loadBand(id: Int) {
+        currentId = id
+        loadJob?.cancel()
+        _uiState.value = BandDetailUiState.Loading
+        loadJob = viewModelScope.launch {
+            _uiState.value = try {
+                BandDetailUiState.Success(getBandDetail(id))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HttpException) {
+                if (e.code() == 404) BandDetailUiState.NotFound
+                else BandDetailUiState.Error(isNetworkError = false)
+            } catch (e: IOException) {
+                BandDetailUiState.Error(isNetworkError = true)
+            } catch (e: Exception) {
+                BandDetailUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+
+    fun retry() {
+        currentId?.let { loadBand(it) }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModelTest"`
+Expected: 4 tests PASS.
+
+---
+
+### Task 19: `AddMusiciansToBandViewModel` con tests (el más complejo)
+
+**Files:**
+- Test: `app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansFormState.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansUiState.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModel.kt`
+
+- [ ] **Step 1: Crear `AddMusiciansFormState.kt` y `AddMusiciansUiState.kt`**
+
+`AddMusiciansFormState.kt`:
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+data class AddMusiciansFormState(
+    val query: String = "",
+    val allMusicians: List<MusicianSummary> = emptyList(),
+    val currentMemberIds: Set<Int> = emptySet(),
+    val filteredAvailable: List<MusicianSummary> = emptyList(),
+)
+```
+
+`AddMusiciansUiState.kt`:
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+sealed interface AddMusiciansUiState {
+    data object Loading : AddMusiciansUiState
+    data object Ready : AddMusiciansUiState
+    data class Adding(val musicianId: Int) : AddMusiciansUiState
+    data class Error(val isNetworkError: Boolean, val musicianId: Int?) : AddMusiciansUiState
+}
+
+sealed interface AddMusiciansEvent {
+    data class AddedSuccessfully(val musicianName: String) : AddMusiciansEvent
+}
+```
+
+- [ ] **Step 2: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddMusiciansToBandViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeMusicianRepo : MusicianRepository {
+        var allMusicians: List<MusicianSummary> = emptyList()
+        override suspend fun getMusicians(): List<MusicianSummary> = allMusicians
+        override suspend fun getMusicianDetail(id: Int) = error("not used")
+    }
+
+    private class FakeBandRepo : BandRepository {
+        var bandResult: Result<Band> = Result.success(sampleBand(emptyList()))
+        var addResult: Result<Unit> = Result.success(Unit)
+        var addCallCount = 0
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = bandResult.getOrThrow()
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+            addCallCount++
+            addResult.getOrThrow()
+        }
+    }
+
+    companion object {
+        fun sampleBand(members: List<MusicianSummary>) = Band(
+            id = 1, name = "Queen", image = "", description = "",
+            creationDate = "", members = members, albums = emptyList(),
+        )
+    }
+
+    private fun buildVm(
+        musicianRepo: FakeMusicianRepo,
+        bandRepo: FakeBandRepo,
+        bandId: Int = 1,
+    ): AddMusiciansToBandViewModel {
+        val savedStateHandle = SavedStateHandle(mapOf("bandId" to bandId))
+        return AddMusiciansToBandViewModel(
+            getMusicians = GetMusiciansUseCase(musicianRepo),
+            getBandDetail = GetBandDetailUseCase(bandRepo),
+            addMusicianToBand = AddMusicianToBandUseCase(bandRepo),
+            savedStateHandle = savedStateHandle,
+        )
+    }
+
+    @Test
+    fun `initial load fetches catalog and band, excludes existing members`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(
+                MusicianSummary(10, "Freddie Mercury", "", ""),
+                MusicianSummary(11, "Brian May", "", ""),
+                MusicianSummary(12, "John Deacon", "", ""),
+            )
+        }
+        val bandRepo = FakeBandRepo().apply {
+            bandResult = Result.success(sampleBand(listOf(MusicianSummary(10, "Freddie Mercury", "", ""))))
+        }
+        val vm = buildVm(musicianRepo, bandRepo)
+
+        vm.form.test {
+            advanceUntilIdle()
+            val state = expectMostRecentItem()
+            assertEquals(3, state.allMusicians.size)
+            assertEquals(setOf(10), state.currentMemberIds)
+            assertEquals(2, state.filteredAvailable.size)
+            assertTrue(state.filteredAvailable.none { it.id == 10 })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `query change with debounce filters by normalized name`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(
+                MusicianSummary(10, "José Pérez", "", ""),
+                MusicianSummary(11, "Brian May", "", ""),
+            )
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onQueryChange("jose")
+        advanceTimeBy(299L)
+        // Aún no debounced
+        assertEquals(2, vm.form.value.filteredAvailable.size)
+
+        advanceTimeBy(1L)
+        advanceUntilIdle()
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+        assertEquals("José Pérez", vm.form.value.filteredAvailable[0].name)
+    }
+
+    @Test
+    fun `query is case and diacritic insensitive`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "José Pérez", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onQueryChange("PEREZ")
+        advanceTimeBy(300L)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+    }
+
+    @Test
+    fun `add musician success transitions Adding to Ready and updates memberIds`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        assertEquals(AddMusiciansUiState.Ready, vm.uiState.value)
+        assertTrue(vm.form.value.currentMemberIds.contains(10))
+        assertEquals(0, vm.form.value.filteredAvailable.size)
+        assertEquals(1, bandRepo.addCallCount)
+    }
+
+    @Test
+    fun `add musician double tap ignores second call while Adding`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo()
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        assertEquals(1, bandRepo.addCallCount)
+    }
+
+    @Test
+    fun `add musician IOException emits network Error without mutating lists`() = runTest {
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo().apply { addResult = Result.failure(IOException("x")) }
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is AddMusiciansUiState.Error)
+        assertTrue((state as AddMusiciansUiState.Error).isNetworkError)
+        assertEquals(10, state.musicianId)
+        assertFalse(vm.form.value.currentMemberIds.contains(10))
+        assertEquals(1, vm.form.value.filteredAvailable.size)
+    }
+
+    @Test
+    fun `add musician HttpException emits non-network Error`() = runTest {
+        val http = HttpException(Response.error<Any>(409, "".toResponseBody("text/plain".toMediaType())))
+        val musicianRepo = FakeMusicianRepo().apply {
+            allMusicians = listOf(MusicianSummary(10, "Freddie", "", ""))
+        }
+        val bandRepo = FakeBandRepo().apply { addResult = Result.failure(http) }
+        val vm = buildVm(musicianRepo, bandRepo)
+        advanceUntilIdle()
+
+        vm.onAddMusician(10)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is AddMusiciansUiState.Error)
+        assertFalse((state as AddMusiciansUiState.Error).isNetworkError)
+    }
+}
+```
+
+- [ ] **Step 3: Run y verificar que falla**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModelTest"`
+Expected: Compilation FAIL.
+
+- [ ] **Step 4: Crear el ViewModel**
+
+```kotlin
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import java.text.Normalizer
+import javax.inject.Inject
+
+@OptIn(FlowPreview::class)
+@HiltViewModel
+class AddMusiciansToBandViewModel @Inject constructor(
+    private val getMusicians: GetMusiciansUseCase,
+    private val getBandDetail: GetBandDetailUseCase,
+    private val addMusicianToBand: AddMusicianToBandUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val bandId: Int = savedStateHandle.get<Int>("bandId")
+        ?: error("AddMusiciansToBandViewModel requires bandId in SavedStateHandle")
+
+    private val _form = MutableStateFlow(AddMusiciansFormState())
+    val form: StateFlow<AddMusiciansFormState> = _form.asStateFlow()
+
+    private val _uiState = MutableStateFlow<AddMusiciansUiState>(AddMusiciansUiState.Loading)
+    val uiState: StateFlow<AddMusiciansUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<AddMusiciansEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AddMusiciansEvent> = _events.asSharedFlow()
+
+    private val queryChannel = MutableStateFlow("")
+
+    init {
+        loadInitial()
+        queryChannel
+            .debounce(300L)
+            .distinctUntilChanged()
+            .onEach { q ->
+                _form.value = _form.value.copy(
+                    query = q,
+                    filteredAvailable = computeFiltered(_form.value.allMusicians, _form.value.currentMemberIds, q),
+                )
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onQueryChange(query: String) {
+        queryChannel.value = query
+    }
+
+    fun onAddMusician(musicianId: Int) {
+        if (_uiState.value is AddMusiciansUiState.Adding) return
+        _uiState.value = AddMusiciansUiState.Adding(musicianId)
+        viewModelScope.launch {
+            try {
+                addMusicianToBand(bandId, musicianId)
+                val musician = _form.value.allMusicians.firstOrNull { it.id == musicianId }
+                _form.value = _form.value.copy(
+                    currentMemberIds = _form.value.currentMemberIds + musicianId,
+                    filteredAvailable = computeFiltered(
+                        _form.value.allMusicians,
+                        _form.value.currentMemberIds + musicianId,
+                        _form.value.query,
+                    ),
+                )
+                _uiState.value = AddMusiciansUiState.Ready
+                if (musician != null) {
+                    _events.tryEmit(AddMusiciansEvent.AddedSuccessfully(musician.name))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = true, musicianId = musicianId)
+            } catch (e: HttpException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+            } catch (e: Exception) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = musicianId)
+            }
+        }
+    }
+
+    private fun loadInitial() {
+        _uiState.value = AddMusiciansUiState.Loading
+        viewModelScope.launch {
+            try {
+                coroutineScope {
+                    val musiciansAsync = async { getMusicians() }
+                    val bandAsync = async { getBandDetail(bandId) }
+                    val (musicians, band) = awaitAll(musiciansAsync, bandAsync)
+                    @Suppress("UNCHECKED_CAST")
+                    val all = musicians as List<com.misw4203.vinilos.domain.model.MusicianSummary>
+                    val bandTyped = band as com.misw4203.vinilos.domain.model.Band
+                    val memberIds = bandTyped.members.map { it.id }.toSet()
+                    _form.value = AddMusiciansFormState(
+                        query = "",
+                        allMusicians = all,
+                        currentMemberIds = memberIds,
+                        filteredAvailable = computeFiltered(all, memberIds, ""),
+                    )
+                    _uiState.value = AddMusiciansUiState.Ready
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = true, musicianId = null)
+            } catch (e: HttpException) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = null)
+            } catch (e: Exception) {
+                _uiState.value = AddMusiciansUiState.Error(isNetworkError = false, musicianId = null)
+            }
+        }
+    }
+
+    fun retry() {
+        loadInitial()
+    }
+
+    private fun computeFiltered(
+        all: List<com.misw4203.vinilos.domain.model.MusicianSummary>,
+        excluded: Set<Int>,
+        query: String,
+    ): List<com.misw4203.vinilos.domain.model.MusicianSummary> {
+        val available = all.filterNot { it.id in excluded }
+        if (query.isBlank()) return available
+        val normalizedQuery = normalize(query)
+        return available.filter { normalize(it.name).contains(normalizedQuery) }
+    }
+
+    private fun normalize(text: String): String {
+        val nfd = Normalizer.normalize(text, Normalizer.Form.NFD)
+        return nfd.replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "").lowercase()
+    }
+}
+```
+
+> Nota sobre `awaitAll` con tipos heterogéneos: Kotlin no infiere bien `awaitAll(async A, async B)` cuando los tipos difieren — la sintaxis con cast `as` aquí es el workaround más limpio sin agregar dependencias.
+
+- [ ] **Step 5: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModelTest"`
+Expected: 7 tests PASS.
+
+- [ ] **Step 6: Commit fase 2**
+
+```bash
+git add app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/ \
+        app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCase.kt \
+        app/src/main/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCase.kt \
+        app/src/main/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCase.kt \
+        app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandsUseCaseTest.kt \
+        app/src/test/java/com/misw4203/vinilos/domain/usecase/GetBandDetailUseCaseTest.kt \
+        app/src/test/java/com/misw4203/vinilos/domain/usecase/AddMusicianToBandUseCaseTest.kt \
+        app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandListViewModelTest.kt \
+        app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/BandDetailViewModelTest.kt \
+        app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt
+
+git commit -m "$(cat <<'EOF'
+feat(hu012): Se agregan UseCases y ViewModels de Bandas
+
+- UseCases: GetBands, GetBandDetail, AddMusicianToBand (3 archivos + 3 tests).
+- BandListViewModel + BandListUiState (Loading/Success/Empty/Error).
+- BandDetailViewModel + BandDetailUiState (Loading/Success/NotFound/Error),
+  con loadJob cancelable y retry.
+- AddMusiciansToBandViewModel separa AddMusiciansFormState (query, allMusicians,
+  currentMemberIds, filteredAvailable) de AddMusiciansUiState (Loading/Ready/
+  Adding/Error). Carga inicial paralela vía async/awaitAll, búsqueda con
+  debounce(300) normalizada (case + diacritic insensitive), defensa contra
+  doble envío en Adding, write-through actualiza memberIds tras éxito.
+- 17 tests unitarios cubren CA02, CA03, CA04, CA05, CA06.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6 — Strings + composables reutilizables (Commit 3)
+
+### Task 20: Agregar strings nuevos a `strings.xml`
+
+**Files:**
+- Modify: `app/src/main/res/values/strings.xml`
+
+- [ ] **Step 1: Agregar el bloque al final del recurso (antes de `</resources>`)**
+
+```xml
+    <!-- HU012 - Bandas -->
+    <string name="artists_tab_musicians">Músicos</string>
+    <string name="artists_tab_bands">Bandas</string>
+    <string name="bands_title">Bandas</string>
+    <string name="band_badge">BANDA</string>
+    <string name="band_detail_title">Detalle de la banda</string>
+    <string name="band_not_found_title">Banda no encontrada</string>
+    <string name="band_not_found_body">La banda solicitada no existe en el catálogo.</string>
+    <string name="band_members_section_title">Integrantes</string>
+    <string name="band_members_empty_title">Aún no hay integrantes</string>
+    <string name="band_members_empty_body">Esta banda todavía no tiene integrantes registrados.</string>
+    <string name="add_first_member_cta">Agregar primer integrante</string>
+    <string name="add_musicians_cta">Agregar músicos</string>
+    <string name="band_albums_section_title">Álbumes</string>
+    <plurals name="members_record_count">
+        <item quantity="one">%d integrante</item>
+        <item quantity="other">%d integrantes</item>
+    </plurals>
+    <plurals name="bands_record_count">
+        <item quantity="one">%d banda · orden alfa</item>
+        <item quantity="other">%d bandas · orden alfa</item>
+    </plurals>
+    <string name="search_placeholder_bands">¿Qué banda buscas?</string>
+
+    <!-- HU012 - Agregar músicos -->
+    <string name="add_musicians_title">Agregar músicos</string>
+    <string name="add_musicians_available_section">Músicos disponibles</string>
+    <string name="add_musicians_current_section">Integrantes actuales</string>
+    <string name="add_musicians_empty_filter">No se encontraron músicos con ese nombre</string>
+    <string name="add_musicians_empty_catalog">No hay músicos disponibles para agregar</string>
+    <string name="search_musicians_placeholder">Buscar por nombre</string>
+    <string name="add_musician_success">«%s» fue agregado a la banda</string>
+    <string name="add_musician_error_network">Sin conexión. Intenta de nuevo.</string>
+    <string name="add_musician_error_server">No pudimos agregar el músico. Inténtalo de nuevo.</string>
+
+    <!-- HU012 - Content descriptions -->
+    <string name="cd_band_image">Imagen de la banda</string>
+    <string name="cd_band_image_of">Imagen de la banda %s</string>
+    <string name="cd_add_musician_to_band">Agregar %s a la banda</string>
+    <string name="cd_adding_musician">Agregando músico</string>
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL (R class regenerada con los nuevos strings).
+
+---
+
+### Task 21: `BandCard` composable con test (TDD)
+
+**Files:**
+- Test: `app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/BandCardTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/components/BandCard.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.domain.model.BandSummary
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class BandCardTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val sample = BandSummary(id = 1, name = "Queen", image = "")
+
+    @Test
+    fun rendersBandName() {
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = {}) }
+        }
+        composeTestRule.onNodeWithText("Queen").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersBandBadge() {
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = {}) }
+        }
+        composeTestRule.onNodeWithText("BANDA").assertIsDisplayed()
+    }
+
+    @Test
+    fun clickTriggersCallback() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme { BandCard(band = sample, onClick = { clicked = true }) }
+        }
+        composeTestRule.onNodeWithText("Queen").performClick()
+        assertTrue(clicked)
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla (compilation)**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: Compilation FAIL — `Unresolved reference: BandCard`.
+
+- [ ] **Step 3: Crear `BandCard.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.BandSummary
+
+@Composable
+fun BandCard(
+    band: BandSummary,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) { role = Role.Button }
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(CircleShape)
+                .background(Color(0xFF1A1A1A)),
+        ) {
+            AsyncImage(
+                model = band.image,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.size(72.dp),
+            )
+        }
+        Spacer(Modifier.width(20.dp))
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = band.name,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.size(4.dp))
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                ) {
+                    Text(
+                        text = stringResource(R.string.band_badge),
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outlineVariant,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** (requiere emulador encendido API 33/34 con animaciones off)
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.presentation.ui.components.BandCardTest`
+Expected: 3 tests PASS. Si no hay emulador disponible, omitir y verificar con `./gradlew :app:assembleDebugAndroidTest` que el test compila.
+
+---
+
+### Task 22: `MusicianRow` composable con test (TDD)
+
+**Files:**
+- Test: `app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/MusicianRowTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.activity.ComponentActivity
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class MusicianRowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val sample = MusicianSummary(10, "Freddie Mercury", "", "1946-09-05")
+
+    @Test
+    fun rendersMusicianName() {
+        composeTestRule.setContent {
+            MaterialTheme { MusicianRow(musician = sample, isAdding = false, onAdd = {}) }
+        }
+        composeTestRule.onNodeWithText("Freddie Mercury").assertIsDisplayed()
+    }
+
+    @Test
+    fun clickPlusInvokesOnAddWithMusicianId() {
+        var addedId: Int? = null
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianRow(musician = sample, isAdding = false, onAdd = { addedId = it })
+            }
+        }
+        val cd = composeTestRule.activity.getString(R.string.cd_add_musician_to_band, "Freddie Mercury")
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        assertEquals(10, addedId)
+    }
+
+    @Test
+    fun whenAddingShowsLoadingIndicatorAndDisablesButton() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme {
+                MusicianRow(musician = sample, isAdding = true, onAdd = { clicked = true })
+            }
+        }
+        val cd = composeTestRule.activity.getString(R.string.cd_adding_musician)
+        composeTestRule.onNodeWithContentDescription(cd).assertIsDisplayed()
+        // Click sobre el indicator no debe disparar onAdd
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        assertEquals(false, clicked)
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla (compilation)**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: Compilation FAIL — `Unresolved reference: MusicianRow`.
+
+- [ ] **Step 3: Crear `MusicianRow.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.MusicianSummary
+
+@Composable
+fun MusicianRow(
+    musician: MusicianSummary,
+    isAdding: Boolean,
+    onAdd: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val addCd = stringResource(R.string.cd_add_musician_to_band, musician.name)
+    val addingCd = stringResource(R.string.cd_adding_musician)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF1A1A1A)),
+            ) {
+                AsyncImage(
+                    model = musician.image,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.size(48.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = musician.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (musician.birthDate.isNotBlank()) {
+                    Text(
+                        text = musician.birthDate.take(10),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        }
+        if (isAdding) {
+            Box(
+                modifier = Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                    .semantics { contentDescription = addingCd },
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                    .clickable { onAdd(musician.id) }
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = addCd
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Add,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.presentation.ui.components.MusicianRowTest`
+Expected: 3 tests PASS.
+
+---
+
+### Task 23: `EmptyMembersState` con test (TDD)
+
+**Files:**
+- Test: `app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersStateTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersState.kt`
+
+- [ ] **Step 1: Escribir el test failing**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.misw4203.vinilos.R
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class EmptyMembersStateTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun rendersEmptyTitleAndBody() {
+        composeTestRule.setContent {
+            MaterialTheme { EmptyMembersState(onAddFirst = {}) }
+        }
+        val title = composeTestRule.activity.getString(R.string.band_members_empty_title)
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun clickCtaInvokesCallback() {
+        var clicked = false
+        composeTestRule.setContent {
+            MaterialTheme { EmptyMembersState(onAddFirst = { clicked = true }) }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.onNodeWithText(cta).performClick()
+        assertTrue(clicked)
+    }
+}
+```
+
+- [ ] **Step 2: Run y verificar que falla**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: Compilation FAIL.
+
+- [ ] **Step 3: Crear `EmptyMembersState.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.misw4203.vinilos.R
+
+@Composable
+fun EmptyMembersState(
+    onAddFirst: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Group,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.size(12.dp))
+        Text(
+            text = stringResource(R.string.band_members_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(6.dp))
+        Text(
+            text = stringResource(R.string.band_members_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(20.dp))
+        Button(
+            onClick = onAddFirst,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+        ) {
+            Text(stringResource(R.string.add_first_member_cta))
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.presentation.ui.components.EmptyMembersStateTest`
+Expected: 2 tests PASS.
+
+---
+
+### Task 24: `PerformerHeader` composable
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/components/PerformerHeader.kt`
+
+- [ ] **Step 1: Crear el composable**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+
+@Composable
+fun PerformerHeader(
+    name: String,
+    image: String,
+    description: String,
+    badgeKind: PerformerBadgeKind,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AsyncImage(
+            model = image,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = name,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(8.dp))
+        Surface(
+            shape = RoundedCornerShape(50),
+            color = MaterialTheme.colorScheme.primaryContainer,
+        ) {
+            Text(
+                text = when (badgeKind) {
+                    PerformerBadgeKind.Band -> stringResource(R.string.band_badge)
+                    PerformerBadgeKind.Artist -> stringResource(R.string.artist_badge)
+                },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 1.sp,
+            )
+        }
+        if (description.isNotBlank()) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+enum class PerformerBadgeKind { Band, Artist }
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit fase 3**
+
+```bash
+git add app/src/main/res/values/strings.xml \
+        app/src/main/java/com/misw4203/vinilos/presentation/ui/components/BandCard.kt \
+        app/src/main/java/com/misw4203/vinilos/presentation/ui/components/MusicianRow.kt \
+        app/src/main/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersState.kt \
+        app/src/main/java/com/misw4203/vinilos/presentation/ui/components/PerformerHeader.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/BandCardTest.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/MusicianRowTest.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/components/EmptyMembersStateTest.kt
+
+git commit -m "$(cat <<'EOF'
+feat(hu012): Se agregan strings y componentes reutilizables de Bandas
+
+- strings.xml: ~30 strings (tabs, títulos, secciones, plurals para members
+  y bands, feedback de éxito/error, content descriptions accesibles).
+- BandCard: análogo a MusicianCard con badge "BANDA", mergeDescendants,
+  role=Button.
+- MusicianRow: fila con foto + nombre + IconButton "+" para la pantalla
+  de agregar; durante isAdding muestra CircularProgressIndicator y
+  deshabilita el click. Touch target ≥ 48dp con sizeIn.
+- EmptyMembersState: vista vacía con CTA "Agregar primer integrante"
+  (CA09).
+- PerformerHeader: encabezado compartido entre BandDetailScreen y
+  futuras pantallas con badge configurable (Band/Artist).
+- 8 tests instrumentados sobre los componentes interactivos.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 7 — Pantallas + navegación (Commit 4)
+
+### Task 25: Refactor `MusicianListScreen` → `MusicianListContent` + nuevo `ArtistsHubScreen`
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreen.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListContent.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ArtistsHubScreen.kt`
+
+- [ ] **Step 1: Crear `MusicianListContent.kt` con el cuerpo actual de `MusicianListScreen` (sin TopBar)**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.EmptyState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
+import com.misw4203.vinilos.presentation.viewmodel.MusicianListUiState
+import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
+
+@Composable
+fun MusicianListContent(
+    onMusicianClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MusicianListViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is MusicianListUiState.Loading -> LoadingState()
+            is MusicianListUiState.Error -> ErrorState(
+                onRetry = viewModel::retry,
+                isNetworkError = state.isNetworkError,
+            )
+            is MusicianListUiState.Empty -> Column {
+                MusicianHeaderSection()
+                EmptyState()
+            }
+            is MusicianListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("artists_list"),
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                item { MusicianHeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.artists_record_count,
+                            state.musicians.size,
+                            state.musicians.size,
+                        ),
+                        testTag = "artists_record_count",
+                    )
+                }
+                items(state.musicians, key = { it.id }) { musician ->
+                    MusicianCard(
+                        musician = musician,
+                        onClick = { onMusicianClick(musician.id) },
+                        modifier = Modifier.testTag("musician_card_${musician.id}"),
+                    )
+                }
+                item { Spacer(Modifier.size(24.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MusicianHeaderSection() {
+    Column {
+        SearchBarStatic(placeholder = stringResource(R.string.search_placeholder_artists))
+        Spacer(Modifier.size(8.dp))
+    }
+}
+```
+
+- [ ] **Step 2: Reemplazar `MusicianListScreen.kt` con un wrapper que delegue (mantiene compatibilidad mientras refactorizamos navegación en Task 29)**
+
+Reemplazar todo el contenido de `MusicianListScreen.kt` con:
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.misw4203.vinilos.presentation.viewmodel.MusicianListViewModel
+
+@Composable
+fun MusicianListScreen(
+    onMusicianClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MusicianListViewModel = hiltViewModel(),
+) {
+    MusicianListContent(
+        onMusicianClick = onMusicianClick,
+        modifier = modifier,
+        viewModel = viewModel,
+    )
+}
+```
+
+> Justificación: el wrapper preserva la API pública usada por `VinilosNavHost` y por tests preexistentes (`MusicianListScreenTest`). Cuando Task 29 actualice la navegación, eliminamos este wrapper y los tests apuntarán a `MusicianListContent` o a `ArtistsHubScreen`.
+
+- [ ] **Step 3: Crear `ArtistsHubScreen.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
+import com.misw4203.vinilos.presentation.ui.screens.band.BandListContent
+
+@Composable
+fun ArtistsHubScreen(
+    onMusicianClick: (Int) -> Unit,
+    onBandClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        VinilosTopBar(title = stringResource(R.string.artists_title))
+        TabRow(
+            selectedTabIndex = selectedTab,
+            containerColor = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { selectedTab = 0 },
+                modifier = Modifier.testTag("artists_tab_musicians"),
+                text = { Text(stringResource(R.string.artists_tab_musicians)) },
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { selectedTab = 1 },
+                modifier = Modifier.testTag("artists_tab_bands"),
+                text = { Text(stringResource(R.string.artists_tab_bands)) },
+            )
+        }
+        when (selectedTab) {
+            0 -> MusicianListContent(onMusicianClick = onMusicianClick)
+            1 -> BandListContent(onBandClick = onBandClick)
+        }
+    }
+}
+```
+
+> `BandListContent` aún no existe — se crea en Task 26. Compilar tras Task 26.
+
+- [ ] **Step 4: Confirmar que NO compila aún (esperando Task 26)**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: Compilation FAIL — `Unresolved reference: BandListContent`. Se resuelve en Task 26.
+
+---
+
+### Task 26: `BandListContent`
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandListContent.kt`
+
+- [ ] **Step 1: Crear el composable**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.BandCard
+import com.misw4203.vinilos.presentation.ui.components.EmptyState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.SearchBarStatic
+import com.misw4203.vinilos.presentation.viewmodel.BandListUiState
+import com.misw4203.vinilos.presentation.viewmodel.BandListViewModel
+
+@Composable
+fun BandListContent(
+    onBandClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: BandListViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val listState = rememberLazyListState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            is BandListUiState.Loading -> LoadingState()
+            is BandListUiState.Error -> ErrorState(
+                onRetry = viewModel::retry,
+                isNetworkError = state.isNetworkError,
+            )
+            is BandListUiState.Empty -> Column {
+                BandHeaderSection()
+                EmptyState()
+            }
+            is BandListUiState.Success -> LazyColumn(
+                modifier = Modifier.testTag("bands_list"),
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                item { BandHeaderSection() }
+                item {
+                    ListCounter(
+                        text = pluralStringResource(
+                            R.plurals.bands_record_count,
+                            state.bands.size,
+                            state.bands.size,
+                        ),
+                        testTag = "bands_record_count",
+                    )
+                }
+                items(state.bands, key = { it.id }) { band ->
+                    BandCard(
+                        band = band,
+                        onClick = { onBandClick(band.id) },
+                        modifier = Modifier.testTag("band_card_${band.id}"),
+                    )
+                }
+                item { Spacer(Modifier.size(24.dp)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandHeaderSection() {
+    Column {
+        SearchBarStatic(placeholder = stringResource(R.string.search_placeholder_bands))
+        Spacer(Modifier.size(8.dp))
+    }
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL — `ArtistsHubScreen` ya resuelve `BandListContent`.
+
+---
+
+### Task 27: `BandDetailScreen` con tests
+
+**Files:**
+- Test: `app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreenTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/BandDetailScreen.kt`
+
+- [ ] **Step 1: Crear `BandDetailScreen.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.PersonAdd
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.presentation.ui.components.EmptyMembersState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.PerformerBadgeKind
+import com.misw4203.vinilos.presentation.ui.components.PerformerHeader
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailUiState
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BandDetailScreen(
+    bandId: Int,
+    onBack: () -> Unit,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+    modifier: Modifier = Modifier,
+    refreshKey: Boolean = false,
+    onRefreshHandled: () -> Unit = {},
+    viewModel: BandDetailViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(bandId) { viewModel.loadBand(bandId) }
+    LaunchedEffect(refreshKey) {
+        if (refreshKey) {
+            viewModel.retry()
+            onRefreshHandled()
+        }
+    }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.band_detail_title),
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("band_detail_back")) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (val state = uiState) {
+                is BandDetailUiState.Loading -> LoadingState()
+                is BandDetailUiState.NotFound -> NotFoundContent()
+                is BandDetailUiState.Error -> ErrorState(
+                    onRetry = viewModel::retry,
+                    isNetworkError = state.isNetworkError,
+                )
+                is BandDetailUiState.Success -> BandBody(
+                    band = state.band,
+                    onMusicianClick = onMusicianClick,
+                    onAddMusicians = onAddMusicians,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandBody(
+    band: Band,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .testTag("band_detail_root"),
+    ) {
+        PerformerHeader(
+            name = band.name,
+            image = band.image,
+            description = band.description,
+            badgeKind = PerformerBadgeKind.Band,
+            contentDescription = stringResource(R.string.cd_band_image_of, band.name),
+        )
+        Spacer(Modifier.height(8.dp))
+
+        MembersSection(
+            members = band.members,
+            onMusicianClick = onMusicianClick,
+            onAddMusicians = onAddMusicians,
+        )
+
+        if (band.albums.isNotEmpty()) {
+            Spacer(Modifier.height(24.dp))
+            AlbumsSection(band.albums)
+        }
+
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun MembersSection(
+    members: List<MusicianSummary>,
+    onMusicianClick: (Int) -> Unit,
+    onAddMusicians: () -> Unit,
+) {
+    SectionHeader(stringResource(R.string.band_members_section_title))
+    Spacer(Modifier.height(8.dp))
+    if (members.isEmpty()) {
+        EmptyMembersState(onAddFirst = onAddMusicians)
+    } else {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            members.forEach { m ->
+                MusicianCard(
+                    musician = m,
+                    onClick = { onMusicianClick(m.id) },
+                    modifier = Modifier.testTag("current_member_${m.id}"),
+                )
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Button(
+            onClick = onAddMusicians,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .height(48.dp)
+                .testTag("band_detail_add_musicians"),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.PersonAdd,
+                contentDescription = null,
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.add_musicians_cta))
+        }
+    }
+}
+
+@Composable
+private fun AlbumsSection(albums: List<Album>) {
+    SectionHeader(stringResource(R.string.band_albums_section_title))
+    Spacer(Modifier.height(8.dp))
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        items(albums) { album ->
+            Column(modifier = Modifier.width(120.dp)) {
+                AsyncImage(
+                    model = album.coverUrl,
+                    contentDescription = stringResource(R.string.cd_album_cover_of, album.name),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = album.name,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (album.releaseYear.isNotBlank()) {
+                    Text(
+                        text = album.releaseYear,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Box(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 24.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
+        )
+    }
+}
+
+@Composable
+private fun NotFoundContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.band_not_found_title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.band_not_found_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Crear test `BandDetailScreenTest.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.SavedStateHandle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.presentation.viewmodel.BandDetailViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+class BandDetailScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakeRepo(val result: Result<Band>) : BandRepository {
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = result.getOrThrow()
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) = error("not used")
+    }
+
+    private fun buildVm(repo: BandRepository) = BandDetailViewModel(GetBandDetailUseCase(repo))
+
+    @Test
+    fun successWithEmptyMembersShowsEmptyMembersStateCta() {
+        val band = Band(1, "Queen", "", "", "", emptyList(), emptyList())
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.onNodeWithText(cta).assertIsDisplayed()
+    }
+
+    @Test
+    fun successWithMembersShowsListAndAddButton() {
+        val band = Band(
+            1, "Queen", "", "", "",
+            members = listOf(MusicianSummary(10, "Freddie", "", "")),
+            albums = emptyList(),
+        )
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Freddie").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("band_detail_add_musicians").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyCtaInvokesOnAddMusicians() {
+        var clicked = false
+        val band = Band(1, "Queen", "", "", "", emptyList(), emptyList())
+        val vm = buildVm(FakeRepo(Result.success(band)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {},
+                    onAddMusicians = { clicked = true },
+                    viewModel = vm,
+                )
+            }
+        }
+        val cta = composeTestRule.activity.getString(R.string.add_first_member_cta)
+        composeTestRule.onNodeWithText(cta).performClick()
+        assertEquals(true, clicked)
+    }
+
+    @Test
+    fun notFoundShowsMessage() {
+        val http404 = HttpException(Response.error<Any>(404, "".toResponseBody("text/plain".toMediaType())))
+        val vm = buildVm(FakeRepo(Result.failure(http404)))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                BandDetailScreen(
+                    bandId = 1, onBack = {}, onMusicianClick = {}, onAddMusicians = {},
+                    viewModel = vm,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule.onAllNodes(
+                androidx.compose.ui.test.hasText(
+                    composeTestRule.activity.getString(R.string.band_not_found_title)
+                )
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        val title = composeTestRule.activity.getString(R.string.band_not_found_title)
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+}
+```
+
+- [ ] **Step 3: Build verify**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Ejecutar tests (requiere emulador encendido)**
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.presentation.ui.screens.band.BandDetailScreenTest`
+Expected: 4 tests PASS. Si no hay emulador, omitir y verificar compilación.
+
+---
+
+### Task 28: `AddMusiciansToBandScreen` con tests
+
+**Files:**
+- Test: `app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt`
+- Create: `app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreen.kt`
+
+- [ ] **Step 1: Crear `AddMusiciansToBandScreen.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.MusicianCard
+import com.misw4203.vinilos.presentation.ui.components.MusicianRow
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansEvent
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansUiState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddMusiciansToBandScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddMusiciansToBandViewModel = hiltViewModel(),
+) {
+    val form by viewModel.form.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val successTemplate = stringResource(R.string.add_musician_success)
+    val networkErrorMessage = stringResource(R.string.add_musician_error_network)
+    val serverErrorMessage = stringResource(R.string.add_musician_error_server)
+
+    LaunchedEffect(viewModel.events) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is AddMusiciansEvent.AddedSuccessfully ->
+                    snackbarHostState.showSnackbar(successTemplate.format(event.musicianName))
+            }
+        }
+    }
+    LaunchedEffect(uiState) {
+        val state = uiState
+        if (state is AddMusiciansUiState.Error && state.musicianId != null) {
+            val msg = if (state.isNetworkError) networkErrorMessage else serverErrorMessage
+            snackbarHostState.showSnackbar(msg)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag("add_musicians_screen_root"),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.add_musicians_title),
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("add_musicians_back")) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (uiState) {
+                AddMusiciansUiState.Loading -> LoadingState()
+                else -> Content(
+                    queryValue = form.query,
+                    onQueryChange = viewModel::onQueryChange,
+                    available = form.filteredAvailable,
+                    currentMembers = form.allMusicians.filter { it.id in form.currentMemberIds },
+                    addingId = (uiState as? AddMusiciansUiState.Adding)?.musicianId,
+                    onAdd = viewModel::onAddMusician,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun Content(
+    queryValue: String,
+    onQueryChange: (String) -> Unit,
+    available: List<com.misw4203.vinilos.domain.model.MusicianSummary>,
+    currentMembers: List<com.misw4203.vinilos.domain.model.MusicianSummary>,
+    addingId: Int?,
+    onAdd: (Int) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            OutlinedTextField(
+                value = queryValue,
+                onValueChange = onQueryChange,
+                placeholder = { Text(stringResource(R.string.search_musicians_placeholder)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("add_musicians_search"),
+            )
+        }
+        item {
+            SectionHeader(stringResource(R.string.add_musicians_available_section))
+        }
+        if (available.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(R.string.add_musicians_empty_filter),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            items(available, key = { it.id }) { musician ->
+                MusicianRow(
+                    musician = musician,
+                    isAdding = addingId == musician.id,
+                    onAdd = onAdd,
+                    modifier = Modifier.testTag("available_musician_${musician.id}"),
+                )
+            }
+        }
+        item {
+            SectionHeader(stringResource(R.string.add_musicians_current_section))
+        }
+        item {
+            Text(
+                text = pluralStringResource(
+                    R.plurals.members_record_count,
+                    currentMembers.size,
+                    currentMembers.size,
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.outline,
+            )
+        }
+        items(currentMembers, key = { it.id }) { musician ->
+            MusicianCard(
+                musician = musician,
+                onClick = {},
+                modifier = Modifier.testTag("current_member_${musician.id}"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        letterSpacing = 1.sp,
+        modifier = Modifier.semantics { heading() },
+    )
+}
+```
+
+- [ ] **Step 2: Crear test `AddMusiciansToBandScreenTest.kt`**
+
+```kotlin
+package com.misw4203.vinilos.presentation.ui.screens.band
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.SavedStateHandle
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.usecase.AddMusicianToBandUseCase
+import com.misw4203.vinilos.domain.usecase.GetBandDetailUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusiciansUseCase
+import com.misw4203.vinilos.presentation.viewmodel.AddMusiciansToBandViewModel
+import org.junit.Rule
+import org.junit.Test
+
+class AddMusiciansToBandScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakeMusicianRepo(val list: List<MusicianSummary>) : MusicianRepository {
+        override suspend fun getMusicians() = list
+        override suspend fun getMusicianDetail(id: Int) = error("not used")
+    }
+
+    private class FakeBandRepo(val band: Band) : BandRepository {
+        var added = mutableListOf<Pair<Int, Int>>()
+        override suspend fun getBands(): List<BandSummary> = error("not used")
+        override suspend fun getBandDetail(id: Int): Band = band
+        override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+            added += bandId to musicianId
+        }
+    }
+
+    private fun buildVm(
+        catalog: List<MusicianSummary>,
+        currentMembers: List<MusicianSummary>,
+        bandId: Int = 1,
+    ): AddMusiciansToBandViewModel {
+        val band = Band(bandId, "Queen", "", "", "", currentMembers, emptyList())
+        return AddMusiciansToBandViewModel(
+            getMusicians = GetMusiciansUseCase(FakeMusicianRepo(catalog)),
+            getBandDetail = GetBandDetailUseCase(FakeBandRepo(band)),
+            addMusicianToBand = AddMusicianToBandUseCase(FakeBandRepo(band)),
+            savedStateHandle = SavedStateHandle(mapOf("bandId" to bandId)),
+        )
+    }
+
+    @Test
+    fun rendersAvailableExcludingExistingMembers() {
+        val catalog = listOf(
+            MusicianSummary(10, "Freddie Mercury", "", ""),
+            MusicianSummary(11, "Brian May", "", ""),
+        )
+        val members = listOf(MusicianSummary(10, "Freddie Mercury", "", ""))
+        val vm = buildVm(catalog, members)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_11")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("available_musician_11").assertIsDisplayed()
+    }
+
+    @Test
+    fun searchFiltersList() {
+        val catalog = listOf(
+            MusicianSummary(10, "Freddie Mercury", "", ""),
+            MusicianSummary(11, "Brian May", "", ""),
+        )
+        val vm = buildVm(catalog, emptyList())
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("add_musicians_search").performTextInput("brian")
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onNodeWithTag("available_musician_11").assertIsDisplayed()
+    }
+
+    @Test
+    fun addingMusicianRemovesFromAvailableList() {
+        val catalog = listOf(MusicianSummary(10, "Freddie Mercury", "", ""))
+        val vm = buildVm(catalog, emptyList())
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AddMusiciansToBandScreen(onBack = {}, viewModel = vm)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        val cd = composeTestRule.activity.getString(
+            com.misw4203.vinilos.R.string.cd_add_musician_to_band, "Freddie Mercury"
+        )
+        composeTestRule.onNodeWithContentDescription(cd).performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5000) {
+            composeTestRule
+                .onAllNodesWithTag("available_musician_10")
+                .fetchSemanticsNodes().isEmpty()
+        }
+        composeTestRule.onNodeWithTag("current_member_10").assertIsDisplayed()
+    }
+}
+```
+
+> Imports adicionales que pueden necesitarse: `androidx.compose.ui.test.onAllNodesWithTag`, `androidx.compose.ui.test.onNodeWithContentDescription`. Si no se autocompletan, agregarlos manualmente.
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Ejecutar tests**
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.presentation.ui.screens.band.AddMusiciansToBandScreenTest`
+Expected: 3 tests PASS.
+
+---
+
+### Task 29: `Destinations.kt` y `VinilosNavHost.kt` — rutas nuevas
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt`
+- Modify: `app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt`
+
+- [ ] **Step 1: Agregar rutas a `Destinations.kt`**
+
+Antes (final del object):
+```kotlin
+    fun addComment(albumId: Long, collectorId: Int = DefaultCollectorId) =
+        "album/$albumId/comment/add/$collectorId"
+}
+```
+
+Después: agregar antes del `}` final:
+```kotlin
+    const val BandDetail = "band/{bandId}"
+    const val BandDetailArg = "bandId"
+    const val AddMusiciansToBand = "band/{bandId}/musicians/add"
+    const val RefreshBandDetailKey = "refresh_band_detail"
+
+    fun bandDetail(bandId: Int) = "band/$bandId"
+    fun addMusiciansToBand(bandId: Int) = "band/$bandId/musicians/add"
+```
+
+- [ ] **Step 2: Modificar `VinilosNavHost.kt`**
+
+Reemplazar el bloque `composable(Destinations.ArtistList) { ... }`:
+
+Antes:
+```kotlin
+                composable(Destinations.ArtistList) {
+                    MusicianListScreen(
+                        onMusicianClick = { id -> navController.navigate("artist/$id") },
+                    )
+                }
+```
+
+Después:
+```kotlin
+                composable(Destinations.ArtistList) {
+                    ArtistsHubScreen(
+                        onMusicianClick = { id -> navController.navigate("artist/$id") },
+                        onBandClick = { id -> navController.navigate(Destinations.bandDetail(id)) },
+                    )
+                }
+```
+
+Y agregar los imports correspondientes:
+```kotlin
+import com.misw4203.vinilos.presentation.ui.screens.artist.ArtistsHubScreen
+import com.misw4203.vinilos.presentation.ui.screens.band.AddMusiciansToBandScreen
+import com.misw4203.vinilos.presentation.ui.screens.band.BandDetailScreen
+```
+
+Quitar el import de `MusicianListScreen` si ya no se usa (el wrapper sigue existiendo pero la navegación ya no lo usa).
+
+Y agregar al final del `NavHost { ... }` (antes del cierre del bloque) los dos destinos nuevos:
+
+```kotlin
+                composable(
+                    route = Destinations.BandDetail,
+                    arguments = listOf(navArgument(Destinations.BandDetailArg) { type = NavType.IntType }),
+                ) { entry ->
+                    val bandId = entry.arguments?.getInt(Destinations.BandDetailArg) ?: return@composable
+                    val refreshFlag by entry.savedStateHandle
+                        .getStateFlow(Destinations.RefreshBandDetailKey, false)
+                        .collectAsStateWithLifecycle()
+                    BandDetailScreen(
+                        bandId = bandId,
+                        onBack = { navController.popBackStack() },
+                        onMusicianClick = { id -> navController.navigate("artist/$id") },
+                        onAddMusicians = {
+                            navController.navigate(Destinations.addMusiciansToBand(bandId))
+                        },
+                        refreshKey = refreshFlag,
+                        onRefreshHandled = {
+                            entry.savedStateHandle[Destinations.RefreshBandDetailKey] = false
+                        },
+                    )
+                }
+                composable(
+                    route = Destinations.AddMusiciansToBand,
+                    arguments = listOf(navArgument(Destinations.BandDetailArg) { type = NavType.IntType }),
+                ) {
+                    AddMusiciansToBandScreen(
+                        onBack = {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(Destinations.RefreshBandDetailKey, true)
+                            navController.popBackStack()
+                        },
+                    )
+                }
+```
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit fase 4**
+
+```bash
+git add app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/ \
+        app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/band/ \
+        app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt \
+        app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/
+
+git commit -m "$(cat <<'EOF'
+feat(hu012): Se agregan pantallas de Bandas y navegación
+
+- Refactor: MusicianListScreen → ArtistsHubScreen con sub-tabs internas
+  (Músicos / Bandas). MusicianListContent extraído sin cambio funcional.
+- BandListContent: lista de bandas reutilizando SearchBarStatic,
+  ListCounter, EmptyState/ErrorState/LoadingState.
+- BandDetailScreen: PerformerHeader + sección Integrantes (con
+  EmptyMembersState CTA si vacía, MusicianCards si tiene) + botón
+  "Agregar músicos" + sección Álbumes opcional. RefreshBandDetailKey
+  para refrescar al volver de la pantalla de agregar.
+- AddMusiciansToBandScreen: header de banda (vía detalle ya en form
+  state), búsqueda con debounce vía VM, sección "Disponibles" con
+  MusicianRow + "+", sección "Integrantes actuales" con ListCounter.
+  Snackbar de éxito ("X agregado a la banda") y de error
+  (red/servidor). Sin botón "Guardar" — cada "+" persiste de inmediato.
+- Destinations: BandDetail, AddMusiciansToBand, RefreshBandDetailKey.
+- VinilosNavHost: reemplaza MusicianListScreen por ArtistsHubScreen y
+  registra los dos destinos nuevos.
+- 7 tests instrumentados (BandDetailScreenTest x4, AddMusiciansToBandScreenTest x3).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 8 — Integración E2E + verificación final (Commit 5)
+
+### Task 30: `FakeBandRepository` para tests instrumentados
+
+**Files:**
+- Create: `app/src/androidTest/java/com/misw4203/vinilos/di/FakeBandRepository.kt`
+
+- [ ] **Step 1: Crear el fake**
+
+```kotlin
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.model.Band
+import com.misw4203.vinilos.domain.model.BandSummary
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.BandRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FakeBandRepository @Inject constructor() : BandRepository {
+
+    private val initialMembers = mutableListOf<MusicianSummary>()
+    private val bandsList = listOf(
+        BandSummary(1, "Queen", ""),
+        BandSummary(2, "Aerosmith", ""),
+    )
+
+    override suspend fun getBands(): List<BandSummary> = bandsList
+
+    override suspend fun getBandDetail(id: Int): Band = Band(
+        id = id,
+        name = if (id == 1) "Queen" else "Aerosmith",
+        image = "",
+        description = "Banda legendaria.",
+        creationDate = "1970-01-01",
+        members = initialMembers.toList(),
+        albums = emptyList(),
+    )
+
+    override suspend fun addMusicianToBand(bandId: Int, musicianId: Int) {
+        if (initialMembers.none { it.id == musicianId }) {
+            initialMembers += MusicianSummary(musicianId, "Rubén Blades", "", "1948-07-16T00:00:00.000Z")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: Compilation FAIL — Hilt no encuentra binding (se resuelve en Task 31).
+
+---
+
+### Task 31: Registrar `FakeBandRepository` en `FakeRepositoryModule`
+
+**Files:**
+- Modify: `app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt`
+
+- [ ] **Step 1: Agregar imports**
+
+```kotlin
+import com.misw4203.vinilos.domain.repository.BandRepository
+```
+
+- [ ] **Step 2: Agregar binding antes del cierre de la clase**
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindBandRepository(impl: FakeBandRepository): BandRepository
+```
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: BUILD SUCCESSFUL.
+
+---
+
+### Task 32: Caso E2E HU012 en `VinilosE2ETest`
+
+**Files:**
+- Modify: `app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt`
+
+- [ ] **Step 1: Leer el archivo actual para entender el estilo de los casos existentes**
+
+Run: `cat app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt`
+Expected: lista de tests con `@Test` que usan `composeRule.waitUntil`, `onNodeWithTag`, `performClick`. Identificar el patrón de un test existente que cubre flujo de detalles para reutilizar el helper de espera (si existe) o copiar la estructura.
+
+- [ ] **Step 2: Agregar el test HU012**
+
+Agregar dentro de la clase, junto a los otros `@Test`:
+
+```kotlin
+    @Test
+    fun hu012_addMusicianToBand_flow() {
+        // 1. Bottom-nav → tab Artistas
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+
+        // 2. Sub-tab "Bandas"
+        composeRule.waitUntil(timeoutMillis = 5000) {
+            composeRule.onAllNodesWithTag("artists_tab_bands").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("artists_tab_bands").performClick()
+
+        // 3. Tap primera banda (band_card_*)
+        composeRule.waitUntil(timeoutMillis = 5000) {
+            composeRule.onAllNodes(
+                SemanticsMatcher.expectValue(SemanticsProperties.TestTag.let { it }, "band_card_1")
+            ).fetchSemanticsNodes().isNotEmpty() ||
+            composeRule.onAllNodesWithTag("band_card_1").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("band_card_1").performClick()
+
+        // 4. Botón "Agregar músicos" (puede ser CTA empty o botón normal)
+        composeRule.waitUntil(timeoutMillis = 5000) {
+            composeRule.onAllNodesWithTag("band_detail_root").fetchSemanticsNodes().isNotEmpty()
+        }
+        val addCtaText = composeRule.activity.getString(R.string.add_first_member_cta)
+        composeRule.onNodeWithText(addCtaText).performClick()
+
+        // 5. En lista de disponibles, tap "+" del primer músico (id=100 por FakeMusicianRepository)
+        composeRule.waitUntil(timeoutMillis = 5000) {
+            composeRule.onAllNodesWithTag("available_musician_100").fetchSemanticsNodes().isNotEmpty()
+        }
+        val addToBandCd = composeRule.activity.getString(R.string.cd_add_musician_to_band, "Rubén Blades")
+        composeRule.onNodeWithContentDescription(addToBandCd).performClick()
+
+        // 6. Verificar que el músico aparece en "Integrantes actuales"
+        composeRule.waitUntil(timeoutMillis = 5000) {
+            composeRule.onAllNodesWithTag("current_member_100").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("current_member_100").assertExists()
+    }
+```
+
+> Imports adicionales que pueden ser necesarios al inicio del archivo: `androidx.compose.ui.test.onNodeWithContentDescription`, `androidx.compose.ui.test.onAllNodesWithTag`. Verificar al compilar.
+
+- [ ] **Step 3: Verify compiles**
+
+Run: `./gradlew :app:assembleDebugAndroidTest`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Ejecutar E2E (requiere emulador encendido API 33/34, animaciones off)**
+
+Preparación del emulador (una vez):
+```bash
+adb shell settings put global window_animation_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global animator_duration_scale 0
+adb shell input keyevent KEYCODE_WAKEUP
+adb shell svc power stayon true
+```
+
+Run: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.misw4203.vinilos.e2e.VinilosE2ETest#hu012_addMusicianToBand_flow`
+Expected: 1 test PASS.
+
+---
+
+### Task 33: Verificación final + commit
+
+- [ ] **Step 1: Build completo**
+
+Run: `./gradlew clean assembleDebug`
+Expected: BUILD SUCCESSFUL en < 5 min.
+
+- [ ] **Step 2: Todos los tests unitarios**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL, todos los tests verdes.
+
+- [ ] **Step 3: Compilar tests instrumentados**
+
+Run: `./gradlew assembleDebugAndroidTest`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: (Opcional) ejecutar suite instrumentada completa**
+
+Run: `./gradlew connectedAndroidTest`
+Expected: BUILD SUCCESSFUL. Si no hay emulador disponible, omitir y dejar evidencia en el PR de que `assembleDebugAndroidTest` compila.
+
+- [ ] **Step 5: Commit fase 5**
+
+```bash
+git add app/src/androidTest/java/com/misw4203/vinilos/di/FakeBandRepository.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt \
+        app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+
+git commit -m "$(cat <<'EOF'
+test(hu012): Se agrega E2E del flujo Agregar Músicos a Banda
+
+- FakeBandRepository en memoria con dos bandas mock y mutación de members
+  en addMusicianToBand (refleja el contrato del backend para que el VM
+  observe el músico recién agregado al refrescar).
+- FakeRepositoryModule registra el binding del fake.
+- VinilosE2ETest: caso hu012_addMusicianToBand_flow cubre Bottom-nav →
+  sub-tab Bandas → detalle → CTA agregar → "+" en disponibles →
+  verificación de que aparece en "Integrantes actuales" (CA01 + CA02 +
+  CA03 + CA09).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:** ✓ Todos los CA están cubiertos (CA01 BandDetailScreenTest + E2E; CA02 AddMusiciansScreenTest + VM test; CA03 VM test + E2E; CA04 VM test exclusión; CA05 VM test debounce + diacritics; CA06 VM test IOException + UI Snackbar; CA07 fluye desde repositorio (no requiere test específico además del E2E); CA08 out of scope; CA09 BandDetailScreenTest empty + EmptyMembersStateTest CTA). Approach C confirmado tras leer `Performer` existente.
+
+**Placeholder scan:** Ningún paso usa "TBD" / "TODO" / "similar to". Cada step incluye código completo o comando exacto con resultado esperado.
+
+**Type consistency:** Nombres de funciones de VM (`onAddMusician`, `onQueryChange`, `retry`, `loadBand`), de UseCases (`invoke`), DAO (`replaceBands`, `upsertDetail`), Repository (`getBands`, `getBandDetail`, `addMusicianToBand`), composables (`BandCard`, `MusicianRow`, `EmptyMembersState`, `PerformerHeader`, `BandListContent`, `BandDetailScreen`, `AddMusiciansToBandScreen`, `ArtistsHubScreen`) consistentes entre tasks. `RefreshBandDetailKey` referenciado consistentemente en VinilosNavHost (Task 29) y como flag en BandDetailScreen.
+
+**Conocidos a vigilar durante implementación:**
+- Task 28 referencia `onAllNodesWithTag` y `onNodeWithContentDescription` — confirmar imports al primer fallo de compilación.
+- Task 32 usa heurística para detectar tag `band_card_1`; si la rama main tiene helpers E2E ya estructurados, alinear el estilo en el commit.
+
+
+---
+
+### Task 7: `BandDao`
+
+**Files:**
+- Create: `app/src/main/java/com/misw4203/vinilos/data/local/dao/BandDao.kt`
+
+- [ ] **Step 1: Write the file**
+
+```kotlin
+package com.misw4203.vinilos.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+
+@Dao
+interface BandDao {
+
+    @Query("SELECT * FROM bands ORDER BY name ASC")
+    suspend fun getAll(): List<BandListEntity>
+
+    @Upsert
+    suspend fun upsertAll(bands: List<BandListEntity>)
+
+    @Query("DELETE FROM bands")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun replaceBands(bands: List<BandListEntity>) {
+        clear()
+        upsertAll(bands)
+    }
+
+    @Query("SELECT * FROM band_details WHERE id = :id")
+    suspend fun getDetailById(id: Int): BandDetailEntity?
+
+    @Upsert
+    suspend fun upsertDetail(detail: BandDetailEntity)
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL
+
+---
+
+### Task 8: Registrar entidades + DAO en `VinilosDatabase` (bump version a 5)
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/data/local/database/VinilosDatabase.kt`
+
+- [ ] **Step 1: Reemplazar `entities`, `version` y agregar abstract method**
+
+Antes:
+```kotlin
+@Database(
+    entities = [
+        AlbumEntity::class,
+        AlbumDetailEntity::class,
+        MusicianListEntity::class,
+        MusicianDetailEntity::class,
+        CollectorEntity::class,
+        CollectorDetailEntity::class,
+    ],
+    version = 4,
+    exportSchema = false,
+)
+@TypeConverters(Converters::class)
+abstract class VinilosDatabase : RoomDatabase() {
+    abstract fun albumDao(): AlbumDao
+    abstract fun musicianDao(): MusicianDao
+    abstract fun collectorDao(): CollectorDao
+}
+```
+
+Después:
+```kotlin
+@Database(
+    entities = [
+        AlbumEntity::class,
+        AlbumDetailEntity::class,
+        MusicianListEntity::class,
+        MusicianDetailEntity::class,
+        CollectorEntity::class,
+        CollectorDetailEntity::class,
+        BandListEntity::class,
+        BandDetailEntity::class,
+    ],
+    version = 5,
+    exportSchema = false,
+)
+@TypeConverters(Converters::class)
+abstract class VinilosDatabase : RoomDatabase() {
+    abstract fun albumDao(): AlbumDao
+    abstract fun musicianDao(): MusicianDao
+    abstract fun collectorDao(): CollectorDao
+    abstract fun bandDao(): BandDao
+}
+```
+
+Y agregar los imports correspondientes:
+```kotlin
+import com.misw4203.vinilos.data.local.dao.BandDao
+import com.misw4203.vinilos.data.local.entity.BandDetailEntity
+import com.misw4203.vinilos.data.local.entity.BandListEntity
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:kspDebugKotlin`
+Expected: BUILD SUCCESSFUL (KSP genera el código de Room para `BandDao`).
+
+---
+
+### Task 9: Proveer `BandDao` en `DatabaseModule`
+
+**Files:**
+- Modify: `app/src/main/java/com/misw4203/vinilos/di/DatabaseModule.kt`
+
+- [ ] **Step 1: Agregar import y método provider**
+
+Añadir el import:
+
+```kotlin
+import com.misw4203.vinilos.data.local.dao.BandDao
+```
+
+Agregar después de `provideCollectorDao`:
+
+```kotlin
+    @Provides
+    fun provideBandDao(db: VinilosDatabase): BandDao = db.bandDao()
+```
+
+- [ ] **Step 2: Verify compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL

--- a/docs/superpowers/specs/2026-05-12-hu012-agregar-musicos-banda-design.md
+++ b/docs/superpowers/specs/2026-05-12-hu012-agregar-musicos-banda-design.md
@@ -1,0 +1,413 @@
+# HU012 — Agregar músicos a una banda — Diseño técnico
+
+| Campo | Valor |
+|---|---|
+| **Fecha** | 2026-05-12 |
+| **Rama** | `feature/HU12_Agregar_Musicos_Banda` |
+| **HU origen** | HU012 — Agregar músicos a una banda |
+| **Estado** | Aprobado por usuario (brainstorming completado) |
+| **Próximo paso** | Plan de implementación (`writing-plans`) |
+
+## 1. Resumen ejecutivo
+
+Esta HU permite a un coleccionista agregar músicos existentes a una banda del catálogo, manteniendo actualizada la composición de la agrupación para todos los usuarios.
+
+El proyecto Android actualmente **no tiene el concepto de Banda** en su dominio. Esta HU introduce:
+
+1. El dominio `Band` alineado al modelo del backend (hermana de `Musician` bajo `Performer`, herencia de tabla única).
+2. Cuatro endpoints nuevos en `VinilosApiService` (`GET /bands`, `GET /bands/{id}`, `GET /bands/{id}/musicians`, `POST /bands/{bandId}/musicians/{musicianId}`).
+3. Tres pantallas nuevas: lista de bandas (como sub-tab dentro de "Artistas"), detalle de banda y "Agregar músicos".
+4. Cobertura de pruebas unitarias, instrumentadas y E2E para los CA01–CA09 (excepto CA08, fuera de scope sin auth).
+
+## 2. Decisiones tomadas durante el brainstorming
+
+| # | Decisión | Razón |
+|---|---|---|
+| D1 | El backend expone `/bands` y `/musicians` como recursos hermanos bajo `Performer`. | Confirmado por el usuario con la documentación del backend. |
+| D2 | Scope strict de la HU: **sin** delete de integrantes, **sin** roles/instrumentos. | El diseño visual local contradice el spec funcional; gana el spec. |
+| D3 | Estilo visual **Material3** (consistente con la app), no el "Brutalist Draftsman" del mockup. | Consistencia con el resto de pantallas existentes. |
+| D4 | Pack completo de pantallas: lista de bandas + detalle de banda + agregar músicos. | Para que el flujo cumpla CA01–CA09 end-to-end. |
+| D5 | Tab "Artistas" se convierte en hub con **sub-tabs internas** ("Músicos" / "Bandas"). | Mantiene el bottom-nav existente intacto (3 tabs) y agrupa por afinidad de dominio. |
+| D6 | Arquitectura: `Performer` como **sealed interface común**, con `Musician` y `Band` como implementaciones. | Refleja el modelo del backend; permite refactor a un `PerformerHeader` compartido. |
+
+### Asunciones por defecto (no preguntadas explícitamente)
+
+- **CA08 — restricción de rol:** la app actualmente no tiene auth (`DefaultCollectorId = 100`). Asumimos siempre coleccionista → la opción "Agregar músicos" siempre se ve. Documentado como deuda técnica.
+- **CA09 — estado vacío:** incluye CTA "Agregar primer integrante" reutilizando el patrón de `EmptyState`.
+- **CA05 — búsqueda:** filtro **local** con `debounce(300ms)`, insensible a mayúsculas/minúsculas y tildes (`Normalizer.normalize(NFD)`).
+- **Confirmación de éxito:** `Snackbar` (patrón consistente con `AddCommentScreen` / `AddTrackScreen`).
+
+## 3. Arquitectura — dominio y datos
+
+### 3.1 Dominio (`domain/model/`)
+
+```
+Performer (sealed interface)
+├─ id: Int
+├─ name: String
+├─ image: String
+├─ description: String
+├─ birthDate: String
+└─ implementaciones:
+    ├─ Musician (data class)              [existente, ajustar para implementar Performer]
+    │   ├─ albums: List<Album>
+    │   └─ prizes: List<MusicianPrize>
+    └─ Band (data class)                  [nuevo]
+        ├─ members: List<MusicianSummary>
+        └─ albums: List<Album>
+
+MusicianSummary (data class)              [existente, se reutiliza para members]
+BandSummary (data class)                  [nuevo: id, name, image]
+```
+
+**Riesgo R7:** existe ya un archivo `domain/model/Performer.kt`. Antes de implementar, verificar si su contenido permite refactor a interfaz común. Si hay colisión irresoluble, degradar a la opción C (Band aislada con header propio, sin abstracción común), sin cambiar el resto del diseño.
+
+### 3.2 Data — Remote (Retrofit)
+
+DTOs nuevos en `data/remote/dto/`:
+- `BandDto` — para lista (`id`, `name`, `image`, `description`).
+- `BandDetailDto` — para detalle (campos anteriores + `musicians: List<MusicianDetailDto>` + `albums: List<AlbumDto>`).
+
+Endpoints nuevos en `VinilosApiService`:
+
+```kotlin
+@GET("bands")
+suspend fun getBands(): List<BandDto>
+
+@GET("bands/{id}")
+suspend fun getBandDetail(@Path("id") id: Int): BandDetailDto
+
+@GET("bands/{id}/musicians")
+suspend fun getBandMembers(@Path("id") id: Int): List<MusicianDetailDto>
+
+@POST("bands/{bandId}/musicians/{musicianId}")
+suspend fun addMusicianToBand(
+    @Path("bandId") bandId: Int,
+    @Path("musicianId") musicianId: Int,
+): retrofit2.Response<Unit>
+```
+
+### 3.3 Data — Local (Room)
+
+- `BandEntity` (mismo patrón que `MusicianEntity`): los `members` se serializan como JSON blob via `Converters` (Gson) — consistente con el patrón existente para `tracks`/`performers`/`comments`.
+- `BandDao` con `replaceBands(...)` (clear + upsert transaccional), `upsertDetail(...)`, `getBands()`, `getBandDetail(id)`.
+- Agregar `BandEntity` a `VinilosDatabase` — bump de versión. `fallbackToDestructiveMigration` ya está activo (la caché es expendable).
+
+### 3.4 Repository
+
+- `domain/repository/BandRepository` (interfaz):
+  - `suspend fun getBands(): List<BandSummary>`
+  - `suspend fun getBandDetail(id: Int): Band`
+  - `suspend fun addMusicianToBand(bandId: Int, musicianId: Int)`
+- `data/repository/BandRepositoryImpl` con la estrategia **network-first + fallback a caché** para lecturas (idéntica a `MusicianRepositoryImpl`) y **write-through cache** para `addMusicianToBand` (POST → si el detalle local existe, read-modify-write para agregar el músico a `members`).
+
+Binding en `RepositoryModule` con `@Binds`.
+
+## 4. Capa de presentación
+
+### 4.1 UseCases nuevos (`domain/usecase/`)
+
+- `GetBandsUseCase(repo)` — `suspend operator fun invoke(): List<BandSummary>`
+- `GetBandDetailUseCase(repo)` — `suspend operator fun invoke(bandId: Int): Band`
+- `AddMusicianToBandUseCase(repo)` — `suspend operator fun invoke(bandId: Int, musicianId: Int)`
+- (Reutilizamos `GetMusiciansUseCase` existente para el catálogo en la pantalla de agregar.)
+
+### 4.2 ViewModels nuevos
+
+**`BandListViewModel`** (`@HiltViewModel`)
+
+```kotlin
+sealed interface BandListUiState {
+    data object Loading : BandListUiState
+    data object Empty : BandListUiState
+    data class Success(val bands: List<BandSummary>) : BandListUiState
+    data class Error(val isNetworkError: Boolean) : BandListUiState
+}
+```
+
+`init { load() }`, `retry()`. Excepciones clasificadas: `CancellationException` rethrow, `IOException` → red, otros → servidor.
+
+**`BandDetailViewModel`** (`@HiltViewModel`, recibe `SavedStateHandle`)
+
+```kotlin
+sealed interface BandDetailUiState {
+    data object Loading : BandDetailUiState
+    data class Success(val band: Band) : BandDetailUiState
+    data object NotFound : BandDetailUiState
+    data class Error(val isNetworkError: Boolean) : BandDetailUiState
+}
+```
+
+- `loadJob` cancelable (patrón `MusicianDetailViewModel`).
+- `retry()` re-ejecuta `GetBandDetailUseCase`.
+- `RefreshBandDetailKey` en `SavedStateHandle`: cuando vuelve de `AddMusiciansToBandScreen`, refresca el detalle.
+
+**`AddMusiciansToBandViewModel`** (separa form state de submit state)
+
+```kotlin
+data class AddMusiciansFormState(
+    val query: String = "",
+    val allMusicians: List<MusicianSummary> = emptyList(),
+    val currentMemberIds: Set<Int> = emptySet(),
+    val filteredAvailable: List<MusicianSummary> = emptyList(),
+)
+
+sealed interface AddMusiciansUiState {
+    data object Loading : AddMusiciansUiState
+    data object Ready : AddMusiciansUiState
+    data class Adding(val musicianId: Int) : AddMusiciansUiState
+    data class Error(val isNetworkError: Boolean, val musicianId: Int?) : AddMusiciansUiState
+}
+```
+
+**Flujo:**
+1. Carga inicial en paralelo (`async`/`awaitAll`): `getMusicians()` + `getBandDetail(bandId)`.
+2. `MutableStateFlow<String>("")` para `query`, con `.debounce(300L).distinctUntilChanged()` → recalcula `filteredAvailable` excluyendo `currentMemberIds` y filtrando por nombre normalizado (`Normalizer.normalize(NFD)` + lowercase + remover diacritics).
+3. `onAddMusician(id)`: si state ya es `Adding(id)`, ignorar (debounce de doble envío). Si no, `Adding(id)` → POST → al volver:
+   - Éxito: agregar `id` a `currentMemberIds`, removerlo de `filteredAvailable`, volver a `Ready`, emitir evento de Snackbar de éxito.
+   - `IOException`: `Error(isNetworkError = true, musicianId = id)`. La lista no se mutó (CA06).
+   - `HttpException`: `Error(isNetworkError = false, musicianId = id)`. Mensaje de error genérico de servidor; si retorna 4xx por duplicado, mensaje específico (defensa en profundidad para CA04).
+   - `CancellationException`: rethrow.
+
+### 4.3 Navegación
+
+`Destinations.kt` agrega:
+
+```kotlin
+const val BandDetail = "band/{bandId}"
+const val BandDetailArg = "bandId"
+const val AddMusiciansToBand = "band/{bandId}/musicians/add"
+const val RefreshBandDetailKey = "refresh_band_detail"
+
+fun bandDetail(bandId: Int) = "band/$bandId"
+fun addMusiciansToBand(bandId: Int) = "band/$bandId/musicians/add"
+```
+
+`VinilosNavHost` registra dos composable destinations nuevas. El bottom-nav existente no cambia.
+
+### 4.4 Pantallas
+
+**Organización por carpetas** (consistente con `album/`, `artist/`, `collector/` existentes):
+
+- `presentation/ui/screens/artist/` — mantiene `MusicianDetailScreen`; renombra `MusicianListScreen` a `ArtistsHubScreen` y extrae su contenido a `MusicianListContent` (en la misma carpeta).
+- `presentation/ui/screens/band/` (nueva carpeta) — `BandListContent`, `BandDetailScreen`, `AddMusiciansToBandScreen`.
+
+**Refactor: `MusicianListScreen` → hub con sub-tabs**
+
+- Renombra el composable a `ArtistsHubScreen`. Su contenido actual se extrae a `MusicianListContent` (sin cambio funcional). Agrega un `TabRow` Material3 con dos `Tab`s: "Músicos" y "Bandas".
+- La tab seleccionada se persiste con `rememberSaveable`. Cada tab inyecta su VM con `hiltViewModel()`.
+
+**`BandListContent`** (sub-tab "Bandas")
+- Reutiliza `SearchBarStatic`, `ListCounter`, `LoadingState`/`EmptyState`/`ErrorState`.
+- `LazyColumn` con `BandCard`. Click → `bandDetail(id)`.
+
+**`BandDetailScreen`** (patrón `MusicianDetailScreen`)
+- `Scaffold` + `TopAppBar` (back + title con `heading()`).
+- `PerformerHeader` reutilizable: imagen circular + nombre (heading) + badge "BANDA" + descripción.
+- Sección **Integrantes**:
+  - `SectionHeader("Integrantes")` con `heading()`.
+  - Si `members.isEmpty()`: `EmptyMembersState` con CTA "Agregar primer integrante" → `addMusiciansToBand(bandId)` (CA09).
+  - Si tiene: lista con `MusicianCard`. Click navega al detalle del músico.
+  - Botón "Agregar músicos" (siempre visible per D-CA08) → `addMusiciansToBand(bandId)` (CA01).
+- Sección **Álbumes** (si vienen del backend): `LazyRow` igual que en `MusicianDetailScreen`.
+
+**`AddMusiciansToBandScreen`** (el corazón de la HU)
+- `Scaffold` + `TopAppBar "Agregar músicos"` (heading) + back. `SnackbarHost`.
+- `LazyColumn` con:
+  1. Header de banda (Card con foto + nombre + badge).
+  2. `OutlinedTextField` con icono `Search`, placeholder "Buscar por nombre". Vinculado al `query` del VM.
+  3. Sección **"Músicos disponibles"** (`SectionHeader` con `heading()`):
+     - Lista `filteredAvailable`.
+     - Cada row: `MusicianRow` (composable nuevo: foto + nombre + `IconButton("+")` a la derecha).
+     - Durante `Adding(thisId)`, el "+" se reemplaza por `CircularProgressIndicator(16dp)` y está deshabilitado (previene doble envío).
+     - Lista vacía tras filtro: `EmptyState` "No se encontraron músicos".
+  4. Sección **"Integrantes actuales"** (`SectionHeader` con `heading()`):
+     - `ListCounter` con plural ("3 integrantes" / "1 integrante").
+     - Lista compacta de los integrantes (sin acción, scope strict).
+- **No** hay botón "Guardar cambios" — cada "+" hace POST inmediato porque el endpoint asocia uno-a-uno. Difiere del mockup pero respeta el backend.
+
+### 4.5 Componentes nuevos (`ui/components/`)
+
+- **`BandCard`** — análogo a `MusicianCard` pero con badge "BANDA". `mergeDescendants = true`, `role = Role.Button`.
+- **`PerformerHeader`** — header compartido (foto + nombre con heading + badge opcional + descripción).
+- **`MusicianRow`** — fila con `IconButton("+")` para la pantalla de agregar.
+- **`EmptyMembersState`** — `EmptyState` parametrizado con CTA opcional para CA09.
+
+### 4.6 Microoptimizaciones (consistencia con el proyecto)
+
+- `derivedStateOf` para `filteredAvailable` (sólo recompone cuando cambian sus inputs).
+- `key()` por `musicianId` en `LazyColumn` (recomposición selectiva por row).
+- `remember(bandId)` en `LaunchedEffect`.
+- `collectAsStateWithLifecycle` (no `collectAsState`).
+- `stringResource` cacheado fuera de `forEach` cuando es invariante.
+
+### 4.7 Strings nuevos (`strings.xml`)
+
+Aproximadamente 18 strings. Tematizados:
+
+- Tabs: `artists_tab_musicians`, `artists_tab_bands`.
+- Bandas: `bands_title`, `band_badge`, `band_detail_title`, `band_not_found_title`, `band_not_found_body`, `band_members_section_title`, `band_members_empty_title`, `band_members_empty_body`, `add_first_member_cta`.
+- Agregar: `add_musicians_title`, `add_musicians_available_section`, `add_musicians_current_section`, `add_musicians_empty_filter`, `search_musicians_placeholder`.
+- Counters: `<plurals name="members_record_count">` (one/other).
+- Feedback: `add_musician_success` ("'{nombre}' agregado a la banda"), `add_musician_error_network`, `add_musician_error_server`, `add_musician_error_duplicate`.
+- Content descriptions: `cd_band_image`, `cd_band_image_of` (`"Imagen de la banda %s"`), `cd_add_musician_to_band` (`"Agregar %s a la banda"`).
+
+### 4.8 Accesibilidad (consistente con la HU previa de a11y)
+
+- Todos los títulos y `SectionHeader`s con `Modifier.semantics { heading() }`.
+- Imágenes con `contentDescription` contextual o `null` si decorativas.
+- Touch targets ≥ 48dp en el botón "+" (sizeIn).
+- `Role.Button` + `mergeDescendants` en cards/rows interactivos.
+- `liveRegion` (Polite/Assertive) en estados Loading/Error/Empty.
+- `Snackbar` con texto descriptivo y `stateDescription` cuando aplique.
+
+## 5. Testing
+
+### 5.1 Unit tests (`app/src/test/`)
+
+**ViewModels** — JUnit4 + MockK + Turbine + `kotlinx-coroutines-test`. Fakes inline.
+
+`BandListViewModelTest`:
+- `init` → `Loading → Success(list)` con lista no vacía.
+- Lista vacía → `Loading → Empty`.
+- `IOException` → `Error(isNetworkError = true)`.
+- `HttpException` → `Error(isNetworkError = false)`.
+- `retry()` re-ejecuta el fetch.
+
+`BandDetailViewModelTest`:
+- `bandId` válido → `Loading → Success(band)`.
+- `HttpException 404` → `NotFound`.
+- Cambio de `bandId` cancela el job previo.
+- `retry()` después de error → recupera.
+
+`AddMusiciansToBandViewModelTest`:
+- Carga inicial paralela → `filteredAvailable` excluye `currentMemberIds` (CA02).
+- Debounce de búsqueda: `advanceTimeBy(299)` no actualiza; `advanceTimeBy(300)` sí (CA05).
+- Búsqueda case/diacritic-insensitive: `"jose"` matchea `"José"`, `"PEREZ"` matchea `"Pérez"` (CA05).
+- `onAddMusician(id)` éxito → `Adding(id)` → `Ready`; `currentMemberIds` incluye `id`; `filteredAvailable` lo excluye (CA03).
+- Doble click al "+" en `Adding(id)`: segundo se ignora, POST no se llama dos veces.
+- `IOException` en POST → `Error(isNetworkError = true, musicianId = id)`. La lista no se mutó (CA06).
+- `HttpException 4xx` → `Error(isNetworkError = false, ...)` con mensaje diferenciado (CA04 defensa).
+- `CancellationException` se rethrows (structured concurrency).
+
+**UseCases** — `mockk` del repositorio, `coVerify` de delegación. Tres tests (uno por UseCase nuevo).
+
+**Repository** — `BandRepositoryImplTest`:
+- `getBands()` success → `replaceBands(...)` llamada con la lista mapeada → retorna lista.
+- `getBands()` con `IOException` y caché poblada → retorna caché; sin caché → rethrows.
+- `getBands()` con `HttpException` → propaga sin tocar caché.
+- `getBandDetail(id)` análogo (upsert vs read-from-cache).
+- `addMusicianToBand(bandId, musicianId)` éxito: si hay detalle cacheado, se mutó `members` (write-through). Si no, se omite mutación local.
+- `addMusicianToBand` con error de red: rethrows, caché intacta (CA06).
+
+### 5.2 Compose UI tests (`app/src/androidTest/`)
+
+Composables pure (`createComposeRule()` + `MaterialTheme`):
+- `BandCardTest`: muestra nombre + badge, click invoca `onClick`, semantics correctas.
+- `MusicianRowTest`: muestra nombre, click "+" invoca `onAdd`. Estado `Adding(thisId)`: "+" deshabilitado + spinner.
+- `EmptyMembersStateTest`: muestra título + CTA, click CTA invoca callback.
+
+Screens (`createAndroidComposeRule<ComponentActivity>()`):
+- `BandDetailScreenTest`:
+  - Loading → `LoadingState`.
+  - Success con `members.isEmpty()` → `EmptyMembersState` con CTA (CA09).
+  - Success con `members.isNotEmpty()` → lista + botón "Agregar músicos" (CA01).
+  - `NotFound` → mensaje + back.
+  - Error de red → `ErrorState` con retry, click invoca VM.
+- `AddMusiciansToBandScreenTest`:
+  - Loading → `LoadingState`.
+  - Ready → header + buscador + disponibles + integrantes (CA02).
+  - Integrantes ya asociados no aparecen en disponibles (CA04 UI).
+  - Click "+": durante `Adding`, spinner reemplaza al "+" y se deshabilita.
+  - Tras éxito: músico desaparece de disponibles y aparece en integrantes; `Snackbar` (CA03).
+  - Error de red: `Snackbar` con mensaje de red; el músico no se movió (CA06).
+  - Búsqueda: filtrar por texto reduce la lista visible (testTags `available_musician_{id}`).
+
+### 5.3 E2E (`app/src/androidTest/.../e2e/VinilosE2ETest.kt`)
+
+Flujo completo HU012 usando `FakeRepositoryModule`:
+
+1. Bottom-nav → "Artistas" → sub-tab "Bandas".
+2. Tap primera `BandCard` (matcher `startsWith("band_card_")`).
+3. En detalle, tap "Agregar músicos".
+4. En lista de disponibles, tap "+" del primer músico.
+5. `composeRule.waitUntil(timeout) { ... }` hasta ver Snackbar de éxito.
+6. Verificar que el músico ahora aparece en "Integrantes actuales".
+7. Back → en detalle de banda, verificar que `members` incluye el músico (CA03 + CA07).
+
+Convenciones del proyecto:
+- `HiltTestRunner` ya configurado.
+- `testTag` prefixes: `band_card_*`, `available_musician_*`, `current_member_*`, `add_musician_button_*`, `add_musicians_screen_root`.
+- Sync vía `waitUntil`, no asume composiciones síncronas.
+- Workarounds: API 33/34, animaciones off, `stayon true`.
+
+### 5.4 Cobertura objetivo
+
+DoD ≥ 80% sobre el código nuevo. Alcanzable porque:
+- UseCases: cobertura completa (delegación + propagación).
+- ViewModels: flows de éxito/error/empty/loading + edge cases (debounce, doble envío).
+- Repository: red/caché/error.
+- Screens: renders por UiState + interacciones clave.
+
+## 6. Mapeo CA ↔ verificación
+
+| CA | Verificado por |
+|---|---|
+| CA01 — botón visible y lista de integrantes | `BandDetailScreenTest` (states Success con/sin members) |
+| CA02 — catálogo con nombre, imagen, info | `AddMusiciansToBandScreenTest` (rows + exclusión de integrantes) |
+| CA03 — agregar exitoso + confirmación + reflejo | VM test + Screen test (Snackbar) + E2E flujo completo |
+| CA04 — prevenir duplicados | VM test (exclusión local) + manejo de 4xx |
+| CA05 — búsqueda con debounce, case/diacritic-insensitive | VM test específico (normalización + timing) |
+| CA06 — error de red con retry, estado consistente | VM test (estado tras IOException) + Screen test retry |
+| CA07 — visibilidad para todos los usuarios | E2E (cualquier ruta hacia detalle muestra integrantes) |
+| CA08 — restricción de rol | **Out of scope** sin auth — deuda técnica documentada |
+| CA09 — empty state con CTA | `BandDetailScreenTest` con `members.isEmpty()` + `EmptyMembersStateTest` |
+
+Nota CA02: la HU pide "nacionalidad", pero `MusicianDetailDto` no expone ese campo (solo `birthDate`). Reemplazamos por `birthDate` (consistente con `MusicianCard` existente). Divergencia documentada.
+
+## 7. Riesgos y mitigaciones
+
+| # | Riesgo | Impacto | Mitigación |
+|---|---|---|---|
+| R1 | Posible colisión de IDs entre `/musicians` y `/bands`. | Medio | El backend usa herencia de tabla única (`Performer`) — IDs únicos globales. Verificar con un fetch real antes de cablear navegación. |
+| R2 | Concurrencia: dos coleccionistas agregando integrantes a la vez. | Bajo | `RefreshBandDetailKey` refresca al volver. Tras cada add exitoso, recargamos `bandDetail` desde red. |
+| R3 | API actual no autentica al coleccionista (CA08 no verificable). | Bajo | Asumimos siempre coleccionista. Documentado como deuda. |
+| R4 | Filtro local caro para catálogos grandes. | Bajo | Catálogo del curso < 100 músicos. `derivedStateOf` + normalización barata. TODO de paginación documentado. |
+| R5 | Migración de Room destructiva (caché borrada). | Bajo | Patrón ya establecido (`fallbackToDestructiveMigration`). Caché es expendable. |
+| R6 | Refactor de `MusicianListScreen` puede romper tests UI existentes. | Medio | Extraer contenido actual a `MusicianListContent` sin cambio funcional; tests existentes apuntan a ese composable. |
+| R7 | Posible colisión con `domain/model/Performer.kt` existente. | Medio | Verificar antes de implementar. Si hay colisión irresoluble, degradar a Band aislada con header propio (sin abstracción común). |
+
+## 8. Plan de entrega
+
+Una sola PR estructurada en 5 commits ordenados:
+
+1. **Domain + Data + tests unitarios de UseCases y Repository** — modelos, DTOs, entity, DAO, API endpoints, repository, useCases, bindings Hilt. Cierra con tests JVM verdes.
+2. **ViewModels + tests** — `BandListViewModel`, `BandDetailViewModel`, `AddMusiciansToBandViewModel`. Tests cubren debounce, doble envío, casos de error.
+3. **Strings + componentes reutilizables + tests UI de componentes** — strings.xml, `BandCard`, `MusicianRow`, `EmptyMembersState`, `PerformerHeader`. Tests de cada composable.
+4. **Pantallas + navegación + tests UI de pantallas** — refactor `MusicianListScreen → ArtistsHubScreen`, `BandDetailScreen`, `AddMusiciansToBandScreen`, `Destinations.kt`, `VinilosNavHost`. Ajustes de tests preexistentes.
+5. **E2E + verificación de build** — extender `VinilosE2ETest`. `./gradlew assembleDebug && ./gradlew test && ./gradlew assembleDebugAndroidTest`.
+
+## 9. Out of scope (futuras HUs)
+
+- Auth + restricción de rol funcional (CA08).
+- Eliminar integrantes (DELETE existe en el backend, no se usa).
+- Roles/instrumentos por integrante (no soportado por el backend).
+- Crear/editar bandas (solo asociar).
+- Paginación del catálogo de músicos.
+- Sincronización en tiempo real entre coleccionistas.
+
+## 10. Patrones del proyecto aplicados
+
+- ✅ Network-first + fallback a caché (lecturas).
+- ✅ Write-through cache (POST `addMusicianToBand`).
+- ✅ `StateFlow<UiState>` con sealed UiStates.
+- ✅ Clasificación de excepciones (`CancellationException` rethrow, IO → red, HTTP → servidor).
+- ✅ `collectAsStateWithLifecycle`, `rememberSaveable`.
+- ✅ `MainDispatcherRule` + `runTest` + `advanceUntilIdle()` en tests.
+- ✅ Fake repos inline (clases anidadas) en VM tests.
+- ✅ Microoptimizaciones: `derivedStateOf`, `key()`, recomposición selectiva.
+- ✅ Accesibilidad: `heading()` en títulos/secciones, `mergeDescendants`, `Role.Button`, touch targets ≥ 48dp, `liveRegion`.
+
+---
+
+**Aprobación**: usuario aprobó el diseño completo el 2026-05-12. Próximo paso: invocar `writing-plans` para construir el plan de implementación detallado.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,16 +4,16 @@ kotlin = "2.2.10"
 ksp = "2.3.2"
 
 # AndroidX
-coreKtx = "1.16.0"
-activityCompose = "1.10.1"
+coreKtx = "1.18.0"
+activityCompose = "1.13.0"
 lifecycleRuntimeKtx = "2.10.0"
 
 # Compose
-composeBom = "2025.05.01"
+composeBom = "2026.05.00"
 navigationCompose = "2.9.8"
 
 # DI
-hilt = "2.54"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 
 # Networking
@@ -21,10 +21,10 @@ retrofit = "2.11.0"
 okhttp = "4.12.0"
 
 # Persistence
-room = "2.7.1"
+room = "2.8.4"
 
 # Async
-coroutines = "1.9.0"
+coroutines = "1.11.0"
 
 # Image
 coil = "2.7.0"
@@ -33,8 +33,8 @@ coil = "2.7.0"
 junit = "4.13.2"
 junitExt = "1.3.0"
 espresso = "3.7.0"
-mockk = "1.13.12"
-turbine = "1.1.0"
+mockk = "1.14.9"
+turbine = "1.2.1"
 
 [libraries]
 # Core


### PR DESCRIPTION
## Resumen

  PR que consolida el trabajo sobre la rama `feature/HU12_Agregar_Musicos_Banda` (13 commits):

  - **HU012 — Agregar músicos a una banda**: dominio + data + UI + E2E. Nueva capa de Bandas (`Band`, `BandSummary`, `BandRepository`, 3 UseCases,
  ViewModels para lista/detalle/agregar), endpoints `GET /bands`, `GET /bands/{id}`, `POST /bands/{bandId}/musicians/{musicianId}`, sub-tabs Músicos/Bandas
  en el hub de Artistas, pantallas `BandListContent` / `BandDetailScreen` / `AddMusiciansToBandScreen`. Room DB v5.
  - **HU09 — Comentar álbum, alineada al contrato del backend**: el cliente ahora permite `rating` 0..5 (acorde a la validación Joi del backend) y preserva
  el `commenter: CollectorSummary?` que devuelve la respuesta del POST y los comentarios anidados del álbum, en lugar de descartarlo en el mapping.
  - **Accesibilidad**: `heading()` semantics, `Role.Button`/`Role.Tab`, `mergeDescendants`, `liveRegion`, `stateDescription` en RatingBar, touch targets ≥
  48dp y content descriptions contextuales en 17 archivos.
  - **Limpieza de warnings**:
    - Lint: **29 → 7** warnings.
    - Deprecaciones Kotlin/Compose: **17 → 0** (`hiltViewModel`, `LocalLifecycleOwner`, `MenuAnchorType`, `TabRow`, `centerAlignedTopAppBarColors` migrados
  a sus paquetes/APIs nuevas).
    - `gradle.properties` saneado (flags ya default removidos; añadido `generateSyncIssueWhenLibraryConstraintsAreEnabled=false`).
    - Bumps: core-ktx 1.16 → 1.18, activity-compose 1.10 → 1.13, compose-bom 2025.05 → 2026.05, room 2.7.1 → 2.8.4, coroutines 1.9 → 1.11, mockk 1.13 →
  1.14, turbine 1.1 → 1.2, hilt 2.54 → 2.59.2.
    - `compileSdk` / `targetSdk` **35 → 36**.
  - **Docs**: spec + plan de HU012 (`docs/superpowers/`) y actualización de README/E2E_TESTS (capa de Bandas, fakes E2E sin backend, testTags nuevos,
  requisitos de emulador).

  ## Metodología

  Implementación con **subagent-driven-development** en 5 batches, cada uno con dos rondas de review (spec compliance + code quality) antes de seguir al
  siguiente.

  ## Métricas

  | Métrica | Δ |
  |---|---|
  | Commits | +13 |
  | Tests JVM nuevos | +30 (11 repo + 3 use cases + 16 ViewModels) |
  | Tests instrumentados nuevos | +5 suites (BandCard, MusicianRow, EmptyMembersState, BandDetailScreen, AddMusiciansToBand) |
  | E2E nuevos | +1 (`hu012_addMusicianToBand_flow`) — suite total 22 E2E |
  | Endpoints | +3 (bandas) |
  | Entidades Room | +2 (`BandListEntity`, `BandDetailEntity`); DB v3 → v5 |

  ## Test plan

  - [ ] `./gradlew test` — todos los unit tests verdes (~145+).
  - [ ] `./gradlew assembleDebug` — APK debug compila sin errores.
  - [ ] `./gradlew lintDebug` — sin errores; 7 warnings remanentes (todos catalogados en `MEJORAS.md` Fase K).
  - [ ] `./gradlew connectedAndroidTest` en emulador API 33/34 con animaciones desactivadas y `stayon true` — 22 E2E corren sin backend gracias a
  `FakeRepositoryModule`.
  - [ ] Smoke manual en device:
    - [ ] Hub Artistas → sub-tab **Bandas** → detalle → "Agregar músicos" → seleccionar uno → snackbar de éxito → integrante visible en el detalle.
    - [ ] Álbum detalle → "+ Comentar" → enviar con **rating 0** → publica sin error.
    - [ ] Rotación de pantalla en `AddMusiciansToBandScreen` tras un error: snackbar no se re-dispara.
    - [ ] Navegar a un detalle de banda → la bottom-nav resalta el tab "Artists" (no "Albums").

  ## Riesgos y notas

  - Room cambia a v5 con `fallbackToDestructiveMigration`; cualquier caché previa en el device se borra al abrir tras este PR (esperado).
  - No se subieron Kotlin 2.3, Retrofit 3 ni OkHttp 5: requieren cambios disruptivos (paquete renombrado, KSP compatible) sin beneficio inmediato. Quedan
  documentados en `MEJORAS.md` para una sesión dedicada.

  ## Referencias

  - Spec: `docs/superpowers/specs/2026-05-12-hu012-agregar-musicos-banda-design.md`
  - Plan: `docs/superpowers/plans/2026-05-12-hu012-agregar-musicos-banda-plan.md`
  - Bitácora de cambios: `MEJORAS.md` (fases H, I, J, K — locales)