### PR TITLE
Feature/hu11 hu15 agregar album coleccionista artista

### DIFF
--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeMusicianRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeMusicianRepository.kt
@@ -22,4 +22,6 @@ class FakeMusicianRepository @Inject constructor() : MusicianRepository {
         albums = listOf(Album(1L, "Buscando América", "", "Rubén Blades", "1984", "Salsa")),
         prizes = emptyList(),
     )
+
+    override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/e2e/VinilosE2ETest.kt
@@ -564,6 +564,108 @@ class VinilosE2ETest {
         composeRule.onNodeWithTag("current_album_2").assertExists()
     }
 
+    // -- HU15: Agregar álbum a músico ------------------------------------------
+
+    /**
+     * HU15-01: el CTA "Agregar álbum" del detalle del músico abre la pantalla
+     * de agregar álbum al artista.
+     */
+    @Test
+    fun hu015_tapAddAlbumCta_opensAddAlbumScreen() {
+        navigateToAddAlbumMusicianScreen()
+        composeRule.onNodeWithTag("add_album_musician_screen").assertIsDisplayed()
+    }
+
+    /**
+     * HU15-02: la pantalla muestra los álbumes disponibles (los que el músico aún no tiene).
+     * Con los fakes: "A Night at the Opera" (id=2) está disponible;
+     * "Buscando América" (id=1) ya es del artista y no aparece en disponibles.
+     */
+    @Test
+    fun hu015_addAlbumScreen_showsAvailableAlbums() {
+        navigateToAddAlbumMusicianScreen()
+
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("available_album_musician_2").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("A Night at the Opera").assertExists()
+    }
+
+    /**
+     * HU15-03: la pantalla muestra la discografía actual del músico.
+     * Con el fake, "Buscando América" (id=1) ya pertenece al artista.
+     */
+    @Test
+    fun hu015_addAlbumScreen_showsCurrentDiscography() {
+        navigateToAddAlbumMusicianScreen()
+
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("current_album_musician_1").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("current_album_musician_1").assertExists()
+    }
+
+    /**
+     * HU15-04: el buscador filtra los álbumes disponibles por nombre.
+     * Escribir "opera" deja solo "A Night at the Opera".
+     */
+    @Test
+    fun hu015_searchFiltersAvailableAlbums() {
+        navigateToAddAlbumMusicianScreen()
+
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("available_album_musician_2").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag("add_album_musician_search")
+            .performClick()
+            .performTextInput("opera")
+
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("available_album_musician_2").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("A Night at the Opera").assertExists()
+    }
+
+    /**
+     * HU15-05: tocar "+" en un álbum disponible lo mueve a la discografía actual
+     * (actualización optimista en el ViewModel).
+     */
+    @Test
+    fun hu015_tapAddButton_movesAlbumToCurrentDiscography() {
+        navigateToAddAlbumMusicianScreen()
+
+        val available = tagStartsWith("available_album_musician_")
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(available).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val addButton = SemanticsMatcher("ContentDescription starts with 'Agregar ' and ends with ' a la discografía'") { node ->
+            val cd = node.config.getOrNull(SemanticsProperties.ContentDescription) ?: return@SemanticsMatcher false
+            cd.any { it.startsWith("Agregar ") && it.endsWith(" a la discografía") }
+        }
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(addButton).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onAllNodes(addButton)[0].performClick()
+
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodesWithTag("current_album_musician_2").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("current_album_musician_2").assertExists()
+    }
+
+    /**
+     * HU15-06: el botón back regresa al detalle del músico.
+     */
+    @Test
+    fun hu015_backButton_returnsToMusicianDetail() {
+        navigateToAddAlbumMusicianScreen()
+        composeRule.onNodeWithTag("add_album_musician_back").performClick()
+        waitForTag("artist_detail_root")
+        composeRule.onNodeWithTag("artist_detail_root").assertIsDisplayed()
+    }
+
     // -- Helpers -------------------------------------------------------------
 
     /** Navega desde la lista de coleccionistas hasta la pantalla de agregar álbum. */
@@ -575,6 +677,20 @@ class VinilosE2ETest {
         waitForTag("collector_detail_root")
         composeRule.onNodeWithTag("collector_add_album_cta").performScrollTo().performClick()
         waitForTag("add_album_collector_screen")
+    }
+
+    /** Navega desde la lista de músicos hasta la pantalla de agregar álbum al artista. */
+    private fun navigateToAddAlbumMusicianScreen() {
+        composeRule.onNodeWithTag("bottom_nav_artists").performClick()
+        waitForTag("artists_list")
+        val musicianCard = tagStartsWith("musician_card_")
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(musicianCard).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onAllNodes(musicianCard)[0].performClick()
+        waitForTag("artist_detail_root")
+        composeRule.onNodeWithTag("musician_add_album_cta").performScrollTo().performClick()
+        waitForTag("add_album_musician_screen")
     }
 
     private fun waitForTag(tag: String) {

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianListScreenTest.kt
@@ -25,6 +25,7 @@ class MusicianListScreenTest {
     ) : MusicianRepository {
         override suspend fun getMusicians(): List<MusicianSummary> = result.getOrThrow()
         override suspend fun getMusicianDetail(id: Int): Musician = error("unused")
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
     }
 
     private fun vm(result: Result<List<MusicianSummary>>) =

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/band/AddMusiciansToBandScreenTest.kt
@@ -34,6 +34,7 @@ class AddMusiciansToBandScreenTest {
     private class FakeMusicianRepo(val list: List<MusicianSummary>) : MusicianRepository {
         override suspend fun getMusicians() = list
         override suspend fun getMusicianDetail(id: Int) = error("not used")
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
     }
 
     private class FakeBandRepo(val band: Band) : BandRepository {

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
@@ -80,4 +80,10 @@ interface VinilosApiService {
         @Path("albumId") albumId: Int,
         @Body request: AddCollectorAlbumRequest,
     ): CollectorAlbumDto
+
+    @POST("musicians/{musicianId}/albums/{albumId}")
+    suspend fun addAlbumToMusician(
+        @Path("musicianId") musicianId: Int,
+        @Path("albumId") albumId: Int,
+    )
 }

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/MusicianRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.misw4203.vinilos.domain.model.Musician
 import com.misw4203.vinilos.domain.model.MusicianPrize
 import com.misw4203.vinilos.domain.model.MusicianSummary
 import com.misw4203.vinilos.domain.repository.MusicianRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -76,6 +77,20 @@ class MusicianRepositoryImpl @Inject constructor(
         albums = albums.map { it.toDomain() },
         prizes = prizes,
     )
+
+    override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = withContext(Dispatchers.IO) {
+        api.addAlbumToMusician(musicianId, albumId)
+        try {
+            val cached = dao.getDetailById(musicianId)
+            if (cached != null) {
+                val newAlbum = api.getAlbum(albumId.toLong()).toDomain()
+                dao.upsertDetail(cached.copy(albums = cached.albums + newAlbum))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) { /* best-effort */ }
+        Unit
+    }
 
     private fun AlbumDto.toDomain() = Album(
         id = id,

--- a/app/src/main/java/com/misw4203/vinilos/domain/repository/MusicianRepository.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/repository/MusicianRepository.kt
@@ -6,4 +6,5 @@ import com.misw4203.vinilos.domain.model.MusicianSummary
 interface MusicianRepository {
     suspend fun getMusicians(): List<MusicianSummary>
     suspend fun getMusicianDetail(id: Int): Musician
+    suspend fun addAlbumToMusician(musicianId: Int, albumId: Int)
 }

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddAlbumToMusicianUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/AddAlbumToMusicianUseCase.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import javax.inject.Inject
+
+class AddAlbumToMusicianUseCase @Inject constructor(
+    private val repository: MusicianRepository,
+) {
+    suspend operator fun invoke(musicianId: Int, albumId: Int) =
+        repository.addAlbumToMusician(musicianId, albumId)
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
@@ -38,6 +38,10 @@ object Destinations {
     const val AddAlbumCollectorArg = "collectorId"
     const val RefreshCollectorDetailKey = "refresh_collector_detail"
 
+    const val AddAlbumToMusician = "musician/{musicianId}/albums/add"
+    const val AddAlbumMusicianArg = "musicianId"
+    const val RefreshMusicianDetailKey = "refresh_musician_detail"
+
     fun albumDetail(albumId: Long) = "album_detail/$albumId"
     fun collectorDetail(collectorId: Int) = "collector/$collectorId"
     fun addTrack(albumId: Long) = "album/$albumId/track/add"
@@ -46,4 +50,5 @@ object Destinations {
     fun bandDetail(bandId: Int) = "band/$bandId"
     fun addMusiciansToBand(bandId: Int) = "band/$bandId/musicians/add"
     fun addAlbumToCollector(collectorId: Int) = "collector/$collectorId/albums/add"
+    fun addAlbumToMusician(musicianId: Int) = "musician/$musicianId/albums/add"
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -29,6 +29,7 @@ import com.misw4203.vinilos.presentation.ui.screens.album.AddTrackScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.AlbumListScreen
 import com.misw4203.vinilos.presentation.ui.screens.album.CreateAlbumScreen
+import com.misw4203.vinilos.presentation.ui.screens.artist.AddAlbumToMusicianScreen
 import com.misw4203.vinilos.presentation.ui.screens.artist.ArtistsHubScreen
 import com.misw4203.vinilos.presentation.ui.screens.artist.MusicianDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.band.AddMusiciansToBandScreen
@@ -168,9 +169,30 @@ fun VinilosNavHost() {
                     arguments = listOf(navArgument("id") { type = NavType.IntType }),
                 ) { backStackEntry ->
                     val id = backStackEntry.arguments?.getInt("id") ?: return@composable
+                    val refreshFlag by backStackEntry.savedStateHandle
+                        .getStateFlow(Destinations.RefreshMusicianDetailKey, false)
+                        .collectAsStateWithLifecycle()
                     MusicianDetailScreen(
                         musicianId = id,
                         onBack = { navController.navigateUp() },
+                        onAddAlbum = { navController.navigate(Destinations.addAlbumToMusician(id)) },
+                        refreshKey = refreshFlag,
+                        onRefreshHandled = {
+                            backStackEntry.savedStateHandle[Destinations.RefreshMusicianDetailKey] = false
+                        },
+                    )
+                }
+                composable(
+                    route = Destinations.AddAlbumToMusician,
+                    arguments = listOf(navArgument(Destinations.AddAlbumMusicianArg) { type = NavType.IntType }),
+                ) {
+                    AddAlbumToMusicianScreen(
+                        onBack = {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(Destinations.RefreshMusicianDetailKey, true)
+                            navController.popBackStack()
+                        },
                     )
                 }
                 composable(Destinations.Collectors) {

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/AddAlbumToMusicianScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/AddAlbumToMusicianScreen.kt
@@ -1,0 +1,393 @@
+package com.misw4203.vinilos.presentation.ui.screens.artist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.viewmodel.AddAlbumToMusicianEvent
+import com.misw4203.vinilos.presentation.viewmodel.AddAlbumToMusicianFormState
+import com.misw4203.vinilos.presentation.viewmodel.AddAlbumToMusicianUiState
+import com.misw4203.vinilos.presentation.viewmodel.AddAlbumToMusicianViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddAlbumToMusicianScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddAlbumToMusicianViewModel = hiltViewModel(),
+) {
+    val form by viewModel.form.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val successTemplate = stringResource(R.string.add_album_musician_success)
+    val networkErrorMessage = stringResource(R.string.add_album_musician_error_network)
+    val serverErrorMessage = stringResource(R.string.add_album_musician_error_server)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is AddAlbumToMusicianEvent.AddedSuccessfully ->
+                    snackbarHostState.showSnackbar(successTemplate.format(event.albumName))
+                is AddAlbumToMusicianEvent.AddFailed -> {
+                    val msg = if (event.isNetworkError) networkErrorMessage else serverErrorMessage
+                    snackbarHostState.showSnackbar(msg)
+                }
+            }
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.testTag("add_album_musician_screen"),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.add_album_musician_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("add_album_musician_back"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                ),
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when (val s = uiState) {
+                AddAlbumToMusicianUiState.Loading -> LoadingState()
+                is AddAlbumToMusicianUiState.Error -> if (s.albumId == null) {
+                    ErrorState(onRetry = viewModel::retry, isNetworkError = s.isNetworkError)
+                } else {
+                    ScreenContent(
+                        form = form,
+                        addingId = null,
+                        onQueryChange = viewModel::onQueryChange,
+                        onAdd = viewModel::onAddAlbum,
+                    )
+                }
+                else -> ScreenContent(
+                    form = form,
+                    addingId = (uiState as? AddAlbumToMusicianUiState.Adding)?.albumId,
+                    onQueryChange = viewModel::onQueryChange,
+                    onAdd = viewModel::onAddAlbum,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScreenContent(
+    form: AddAlbumToMusicianFormState,
+    addingId: Int?,
+    onQueryChange: (String) -> Unit,
+    onAdd: (Int) -> Unit,
+) {
+    val currentAlbums = form.allAlbums.filter { it.id in form.currentAlbumIds }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            SectionHeader(stringResource(R.string.add_album_musician_search_section))
+        }
+
+        item {
+            OutlinedTextField(
+                value = form.query,
+                onValueChange = onQueryChange,
+                placeholder = {
+                    Text(
+                        text = stringResource(R.string.add_album_musician_search_placeholder),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Search,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("add_album_musician_search"),
+            )
+        }
+
+        if (form.filteredAvailable.isEmpty() && form.query.isNotBlank()) {
+            item {
+                Text(
+                    text = stringResource(R.string.add_album_musician_empty_filter),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .padding(vertical = 8.dp)
+                        .testTag("add_album_musician_empty_filter"),
+                )
+            }
+        } else {
+            items(form.filteredAvailable, key = { it.id }) { album ->
+                AlbumRow(
+                    album = album,
+                    isAdding = addingId == album.id.toInt(),
+                    onAdd = { onAdd(album.id.toInt()) },
+                    modifier = Modifier.testTag("available_album_musician_${album.id}"),
+                )
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(start = 72.dp),
+                )
+            }
+        }
+
+        item {
+            Spacer(Modifier)
+            SectionHeader(stringResource(R.string.add_album_musician_current_section))
+        }
+
+        if (currentAlbums.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(R.string.add_album_musician_empty_collection),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+        } else {
+            item {
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.musician_albums_count,
+                        currentAlbums.size,
+                        currentAlbums.size,
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            items(currentAlbums, key = { "current_${it.id}" }) { album ->
+                CurrentAlbumItem(
+                    album = album,
+                    modifier = Modifier.testTag("current_album_musician_${album.id}"),
+                )
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(start = 72.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumRow(
+    album: Album,
+    isAdding: Boolean,
+    onAdd: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(vertical = 12.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = album.coverUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(52.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = album.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (album.artistName.isNotBlank()) {
+                Text(
+                    text = album.artistName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+            if (album.releaseYear.isNotBlank()) {
+                Text(
+                    text = album.releaseYear,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+        }
+        if (isAdding) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        } else {
+            IconButton(
+                onClick = onAdd,
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.cd_add_album_to_musician, album.name),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentAlbumItem(
+    album: Album,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = album.coverUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(52.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = album.name,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (album.artistName.isNotBlank()) {
+                Text(
+                    text = album.artistName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .padding(horizontal = 10.dp, vertical = 4.dp),
+        ) {
+            Text(
+                text = "✓",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        letterSpacing = 1.sp,
+        modifier = Modifier.semantics { heading() },
+    )
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
@@ -262,7 +262,7 @@ private fun AlbumsSection(albums: List<Album>, onAddAlbum: () -> Unit) {
     ) {
         Text(
             text = stringResource(R.string.artist_section_albums),
-            style = MaterialTheme.typography.titleMedium,
+            style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.semantics { heading() },
         )
@@ -308,8 +308,9 @@ private fun AlbumsSection(albums: List<Album>, onAddAlbum: () -> Unit) {
         )
     } else {
         LazyRow(
-            contentPadding = PaddingValues(horizontal = 24.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
         ) {
             items(albums) { album ->
                 AlbumCard(album)
@@ -322,7 +323,7 @@ private fun AlbumsSection(albums: List<Album>, onAddAlbum: () -> Unit) {
 private fun AlbumCard(album: Album) {
     Column(
         modifier = Modifier
-            .width(120.dp)
+            .width(96.dp)
             .semantics(mergeDescendants = true) {},
     ) {
         AsyncImage(
@@ -330,7 +331,7 @@ private fun AlbumCard(album: Album) {
             contentDescription = stringResource(R.string.cd_album_cover_of, album.name),
             contentScale = ContentScale.Crop,
             modifier = Modifier
-                .size(120.dp)
+                .size(96.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),
         )

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/artist/MusicianDetailScreen.kt
@@ -22,8 +22,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -74,9 +77,18 @@ import com.misw4203.vinilos.presentation.viewmodel.MusicianDetailViewModel
 fun MusicianDetailScreen(
     musicianId: Int,
     onBack: () -> Unit,
+    onAddAlbum: () -> Unit = {},
+    refreshKey: Boolean = false,
+    onRefreshHandled: () -> Unit = {},
     viewModel: MusicianDetailViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(musicianId) { viewModel.loadMusician(musicianId) }
+    LaunchedEffect(refreshKey) {
+        if (refreshKey) {
+            viewModel.loadMusician(musicianId)
+            onRefreshHandled()
+        }
+    }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
@@ -108,7 +120,7 @@ fun MusicianDetailScreen(
                     onRetry = viewModel::retry,
                     isNetworkError = state.isNetworkError,
                 )
-                is MusicianDetailUiState.Success -> MusicianBody(state.musician)
+                is MusicianDetailUiState.Success -> MusicianBody(state.musician, onAddAlbum)
             }
         }
     }
@@ -139,7 +151,7 @@ private fun NotFoundContent() {
 }
 
 @Composable
-private fun MusicianBody(musician: Musician) {
+private fun MusicianBody(musician: Musician, onAddAlbum: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -150,7 +162,7 @@ private fun MusicianBody(musician: Musician) {
         Spacer(Modifier.height(24.dp))
         DescriptionSection(musician.description)
         Spacer(Modifier.height(24.dp))
-        AlbumsSection(musician.albums)
+        AlbumsSection(musician.albums, onAddAlbum)
         Spacer(Modifier.height(24.dp))
         PrizesSection(musician.prizes)
         Spacer(Modifier.height(24.dp))
@@ -240,15 +252,68 @@ private fun DescriptionSection(description: String) {
 }
 
 @Composable
-private fun AlbumsSection(albums: List<Album>) {
-    SectionHeader(stringResource(R.string.artist_section_albums))
-    Spacer(Modifier.height(8.dp))
-    LazyRow(
-        contentPadding = PaddingValues(horizontal = 24.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+private fun AlbumsSection(albums: List<Album>, onAddAlbum: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        items(albums) { album ->
-            AlbumCard(album)
+        Text(
+            text = stringResource(R.string.artist_section_albums),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.width(12.dp))
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+        )
+        Spacer(Modifier.width(12.dp))
+        Button(
+            onClick = onAddAlbum,
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.onSurface,
+                contentColor = MaterialTheme.colorScheme.surface,
+            ),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                horizontal = 14.dp,
+                vertical = 6.dp,
+            ),
+            modifier = Modifier.testTag("musician_add_album_cta"),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.add_album_musician_cta),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+    if (albums.isEmpty()) {
+        Text(
+            text = stringResource(R.string.add_album_musician_empty_collection),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp),
+        )
+    } else {
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            items(albums) { album ->
+                AlbumCard(album)
+            }
         }
     }
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/collector/CollectorDetailScreen.kt
@@ -267,8 +267,8 @@ private fun CollectorDetailContent(
 private fun SectionHeader(title: String) {
     Text(
         text = title.uppercase(),
-        style = MaterialTheme.typography.labelSmall,
-        fontWeight = FontWeight.SemiBold,
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.semantics { heading() },
     )

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianFormState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianFormState.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Album
+
+data class AddAlbumToMusicianFormState(
+    val query: String = "",
+    val allAlbums: List<Album> = emptyList(),
+    val currentAlbumIds: Set<Long> = emptySet(),
+    val filteredAvailable: List<Album> = emptyList(),
+)

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianUiState.kt
@@ -1,0 +1,13 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+sealed interface AddAlbumToMusicianUiState {
+    data object Loading : AddAlbumToMusicianUiState
+    data object Ready : AddAlbumToMusicianUiState
+    data class Adding(val albumId: Int) : AddAlbumToMusicianUiState
+    data class Error(val isNetworkError: Boolean, val albumId: Int?) : AddAlbumToMusicianUiState
+}
+
+sealed interface AddAlbumToMusicianEvent {
+    data class AddedSuccessfully(val albumName: String) : AddAlbumToMusicianEvent
+    data class AddFailed(val isNetworkError: Boolean) : AddAlbumToMusicianEvent
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianViewModel.kt
@@ -1,0 +1,134 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.usecase.AddAlbumToMusicianUseCase
+import com.misw4203.vinilos.domain.usecase.GetAlbumsUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusicianDetailUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import java.text.Normalizer
+import javax.inject.Inject
+
+@HiltViewModel
+class AddAlbumToMusicianViewModel @Inject constructor(
+    private val getAlbums: GetAlbumsUseCase,
+    private val getMusicianDetail: GetMusicianDetailUseCase,
+    private val addAlbumToMusician: AddAlbumToMusicianUseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    val musicianId: Int = checkNotNull(savedStateHandle.get<Int>(Destinations.AddAlbumMusicianArg)) {
+        "AddAlbumToMusicianViewModel requires musicianId in SavedStateHandle"
+    }
+
+    private val _form = MutableStateFlow(AddAlbumToMusicianFormState())
+    val form: StateFlow<AddAlbumToMusicianFormState> = _form.asStateFlow()
+
+    private val _uiState = MutableStateFlow<AddAlbumToMusicianUiState>(AddAlbumToMusicianUiState.Loading)
+    val uiState: StateFlow<AddAlbumToMusicianUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<AddAlbumToMusicianEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AddAlbumToMusicianEvent> = _events.asSharedFlow()
+
+    init {
+        loadInitial()
+    }
+
+    fun onQueryChange(query: String) {
+        _form.value = _form.value.copy(
+            query = query,
+            filteredAvailable = computeFiltered(_form.value.allAlbums, _form.value.currentAlbumIds, query),
+        )
+    }
+
+    fun onAddAlbum(albumId: Int) {
+        if (_uiState.value is AddAlbumToMusicianUiState.Adding) return
+        _uiState.value = AddAlbumToMusicianUiState.Adding(albumId)
+        viewModelScope.launch {
+            try {
+                addAlbumToMusician(musicianId, albumId)
+                val album = _form.value.allAlbums.firstOrNull { it.id == albumId.toLong() }
+                val newIds = _form.value.currentAlbumIds + albumId.toLong()
+                _form.value = _form.value.copy(
+                    currentAlbumIds = newIds,
+                    filteredAvailable = computeFiltered(_form.value.allAlbums, newIds, _form.value.query),
+                )
+                _uiState.value = AddAlbumToMusicianUiState.Ready
+                if (album != null) {
+                    _events.tryEmit(AddAlbumToMusicianEvent.AddedSuccessfully(album.name))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = true, albumId = albumId)
+                _events.tryEmit(AddAlbumToMusicianEvent.AddFailed(isNetworkError = true))
+            } catch (e: HttpException) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = false, albumId = albumId)
+                _events.tryEmit(AddAlbumToMusicianEvent.AddFailed(isNetworkError = false))
+            } catch (e: Exception) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = false, albumId = albumId)
+                _events.tryEmit(AddAlbumToMusicianEvent.AddFailed(isNetworkError = false))
+            }
+        }
+    }
+
+    fun retry() {
+        loadInitial()
+    }
+
+    private fun loadInitial() {
+        _uiState.value = AddAlbumToMusicianUiState.Loading
+        viewModelScope.launch {
+            try {
+                coroutineScope {
+                    val albumsAsync = async { getAlbums() }
+                    val musicianAsync = async { getMusicianDetail(musicianId) }
+                    val albums = albumsAsync.await()
+                    val musician = musicianAsync.await()
+                    val currentIds = musician.albums.map { it.id }.toSet()
+                    _form.value = AddAlbumToMusicianFormState(
+                        allAlbums = albums,
+                        currentAlbumIds = currentIds,
+                        filteredAvailable = computeFiltered(albums, currentIds, ""),
+                    )
+                    _uiState.value = AddAlbumToMusicianUiState.Ready
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = true, albumId = null)
+            } catch (e: HttpException) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = false, albumId = null)
+            } catch (e: Exception) {
+                _uiState.value = AddAlbumToMusicianUiState.Error(isNetworkError = false, albumId = null)
+            }
+        }
+    }
+
+    private fun computeFiltered(all: List<Album>, excluded: Set<Long>, query: String): List<Album> {
+        val available = all.filterNot { it.id in excluded }
+        if (query.isBlank()) return available
+        val normalizedQuery = normalize(query)
+        return available.filter { normalize(it.name).contains(normalizedQuery) }
+    }
+
+    private fun normalize(text: String): String {
+        val nfd = Normalizer.normalize(text, Normalizer.Form.NFD)
+        return nfd.replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "").lowercase()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,4 +192,21 @@
     <string name="cd_band_image_of">Imagen de la banda %s</string>
     <string name="cd_add_musician_to_band">Agregar %s a la banda</string>
     <string name="cd_adding_musician">Agregando músico</string>
+
+    <!-- HU15 - Agregar álbum a músico -->
+    <string name="add_album_musician_title">Añadir álbum al artista</string>
+    <string name="add_album_musician_cta">Agregar álbum</string>
+    <string name="add_album_musician_search_section">Buscar álbum</string>
+    <string name="add_album_musician_search_placeholder">Buscar por título…</string>
+    <string name="add_album_musician_empty_filter">No se encontraron álbumes con ese nombre</string>
+    <string name="add_album_musician_current_section">Álbumes del artista</string>
+    <string name="add_album_musician_empty_collection">Aún no hay álbumes asociados a este artista</string>
+    <string name="add_album_musician_success">«%s» fue añadido a la discografía</string>
+    <string name="add_album_musician_error_network">Sin conexión. Intenta de nuevo.</string>
+    <string name="add_album_musician_error_server">No pudimos agregar el álbum. Inténtalo de nuevo.</string>
+    <string name="cd_add_album_to_musician">Agregar %s a la discografía</string>
+    <plurals name="musician_albums_count">
+        <item quantity="one">%d álbum en la discografía</item>
+        <item quantity="other">%d álbumes en la discografía</item>
+    </plurals>
 </resources>

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddAlbumToMusicianViewModelTest.kt
@@ -1,0 +1,200 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Album
+import com.misw4203.vinilos.domain.model.Musician
+import com.misw4203.vinilos.domain.model.MusicianSummary
+import com.misw4203.vinilos.domain.repository.AlbumRepository
+import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.usecase.AddAlbumToMusicianUseCase
+import com.misw4203.vinilos.domain.usecase.GetAlbumsUseCase
+import com.misw4203.vinilos.domain.usecase.GetMusicianDetailUseCase
+import com.misw4203.vinilos.presentation.navigation.Destinations
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddAlbumToMusicianViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakeMusicianRepo(
+        var musicianResult: Result<Musician> = Result.success(sampleMusician()),
+        var addResult: Result<Unit> = Result.success(Unit),
+    ) : MusicianRepository {
+        override suspend fun getMusicians(): List<MusicianSummary> = emptyList()
+        override suspend fun getMusicianDetail(id: Int): Musician = musicianResult.getOrThrow()
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = addResult.getOrThrow()
+    }
+
+    private class FakeAlbumRepo(
+        private val albums: List<Album> = sampleAlbums(),
+    ) : AlbumRepository {
+        override suspend fun getAlbums(): List<Album> = albums
+        override suspend fun getAlbumById(id: Long) = error("not used")
+        override suspend fun addTrack(albumId: Long, request: com.misw4203.vinilos.data.remote.dto.CreateTrackRequest) = error("not used")
+        override suspend fun addComment(albumId: Long, description: String, rating: Int, collectorId: Int) = error("not used")
+        override suspend fun createAlbum(input: com.misw4203.vinilos.domain.model.CreateAlbumInput) = error("not used")
+    }
+
+    private fun buildViewModel(
+        musicianRepo: FakeMusicianRepo = FakeMusicianRepo(),
+        albumRepo: FakeAlbumRepo = FakeAlbumRepo(),
+        musicianId: Int = 100,
+    ) = AddAlbumToMusicianViewModel(
+        getAlbums = GetAlbumsUseCase(albumRepo),
+        getMusicianDetail = GetMusicianDetailUseCase(musicianRepo),
+        addAlbumToMusician = AddAlbumToMusicianUseCase(musicianRepo),
+        savedStateHandle = SavedStateHandle(mapOf(Destinations.AddAlbumMusicianArg to musicianId)),
+    )
+
+    @Test
+    fun `starts Loading then emits Ready with available albums excluding current`() = runTest {
+        val vm = buildViewModel()
+
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Ready, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        // Musician has album id=1; catalog has id=1 and id=2 → only id=2 available
+        val form = vm.form.value
+        assertEquals(1, form.filteredAvailable.size)
+        assertEquals(2L, form.filteredAvailable[0].id)
+        assertEquals(1, form.currentAlbumIds.size)
+        assertTrue(1L in form.currentAlbumIds)
+    }
+
+    @Test
+    fun `emits network Error when repositories throw IOException`() = runTest {
+        val vm = buildViewModel(musicianRepo = FakeMusicianRepo(musicianResult = Result.failure(IOException("offline"))))
+
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Error(isNetworkError = true, albumId = null), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits server Error when repositories throw HttpException`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(500, "".toResponseBody("text/plain".toMediaType()))
+        )
+        val vm = buildViewModel(musicianRepo = FakeMusicianRepo(musicianResult = Result.failure(httpError)))
+
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Error(isNetworkError = false, albumId = null), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onAddAlbum success moves album from available to current and emits event`() = runTest {
+        val vm = buildViewModel()
+
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Ready, awaitItem())
+
+            vm.onAddAlbum(2)
+
+            assertEquals(AddAlbumToMusicianUiState.Adding(2), awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Ready, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue(2L in vm.form.value.currentAlbumIds)
+        assertFalse(vm.form.value.filteredAvailable.any { it.id == 2L })
+    }
+
+    @Test
+    fun `onAddAlbum network failure emits Error state and AddFailed event`() = runTest {
+        val musicianRepo = FakeMusicianRepo(addResult = Result.failure(IOException("offline")))
+        val vm = buildViewModel(musicianRepo = musicianRepo)
+
+        var capturedEvent: AddAlbumToMusicianEvent? = null
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Ready, awaitItem())
+
+            vm.events.test {
+                vm.onAddAlbum(2)
+                assertEquals(AddAlbumToMusicianUiState.Adding(2), awaitItem())
+                advanceUntilIdle()
+                capturedEvent = awaitItem()
+                cancelAndIgnoreRemainingEvents()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertTrue(capturedEvent is AddAlbumToMusicianEvent.AddFailed)
+        assertTrue((capturedEvent as AddAlbumToMusicianEvent.AddFailed).isNetworkError)
+    }
+
+    @Test
+    fun `onQueryChange filters available albums by name`() = runTest {
+        val vm = buildViewModel()
+        advanceUntilIdle()
+
+        vm.onQueryChange("opera")
+
+        val filtered = vm.form.value.filteredAvailable
+        assertEquals(1, filtered.size)
+        assertEquals("A Night at the Opera", filtered[0].name)
+    }
+
+    @Test
+    fun `retry re-loads data after error`() = runTest {
+        val musicianRepo = FakeMusicianRepo(musicianResult = Result.failure(IOException("offline")))
+        val vm = buildViewModel(musicianRepo = musicianRepo)
+
+        vm.uiState.test {
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Error(isNetworkError = true, albumId = null), awaitItem())
+
+            musicianRepo.musicianResult = Result.success(sampleMusician())
+            vm.retry()
+
+            assertEquals(AddAlbumToMusicianUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(AddAlbumToMusicianUiState.Ready, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+
+private fun sampleMusician() = Musician(
+    id = 100,
+    name = "Rubén Blades",
+    image = "",
+    description = "Cantante panameño.",
+    birthDate = "1948-07-16T00:00:00.000Z",
+    albums = listOf(Album(1L, "Buscando América", "", "Rubén Blades", "1984", "Salsa")),
+    prizes = emptyList(),
+)
+
+private fun sampleAlbums() = listOf(
+    Album(1L, "Buscando América", "", "Rubén Blades", "1984", "Salsa"),
+    Album(2L, "A Night at the Opera", "", "Queen", "1975", "Rock"),
+)

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/AddMusiciansToBandViewModelTest.kt
@@ -37,6 +37,7 @@ class AddMusiciansToBandViewModelTest {
         var allMusicians: List<MusicianSummary> = emptyList()
         override suspend fun getMusicians(): List<MusicianSummary> = allMusicians
         override suspend fun getMusicianDetail(id: Int): Musician = error("not used")
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
     }
 
     private class FakeBandRepo : BandRepository {

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/MusicianDetailViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/MusicianDetailViewModelTest.kt
@@ -29,6 +29,7 @@ class MusicianDetailViewModelTest {
         var detailResult: Result<Musician> = Result.success(sampleMusician())
         override suspend fun getMusicians(): List<MusicianSummary> = emptyList()
         override suspend fun getMusicianDetail(id: Int): Musician = detailResult.getOrThrow()
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
     }
 
     private fun buildViewModel(repo: FakeMusicianRepository) =

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/MusicianListViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/MusicianListViewModelTest.kt
@@ -33,6 +33,7 @@ class MusicianListViewModelTest {
             return nextResult.getOrThrow()
         }
         override suspend fun getMusicianDetail(id: Int): Musician = error("not used")
+        override suspend fun addAlbumToMusician(musicianId: Int, albumId: Int) = Unit
     }
 
     private fun buildViewModel(repo: FakeMusicianRepository) =


### PR DESCRIPTION
Feature: Agregar álbum a coleccionista (HU11) y a artista (HU15)

  ---
  HU11 — Agregar álbum a coleccionista
  
  Funcionalidad implementada
  - Pantalla AddAlbumToCollectorScreen con búsqueda de álbumes disponibles, formulario de condiciones de venta (precio + estado) y sección de colección actual
  - Endpoint POST /collectors/{collectorId}/albums/{albumId} con body { price, status }
  - Actualización optimista en el ViewModel: el álbum pasa a "Mi colección actual" inmediatamente sin esperar respuesta del servidor
  - Exclusión automática de álbumes ya en la colección (currentAlbumIds: Set<Long>)
  - Navegación desde CollectorDetailScreen con botón "Agregar álbum" y regreso con refresco del detalle via SavedStateHandle

  Bugs corregidos post-implementación
  - Al volver al detalle, el álbum recién agregado aparecía sin nombre ni portada: corregido en CollectorRepositoryImpl.getCollectorDetail llamando en paralelo a GET /collectors/{id}/albums
  para enriquecer los datos cuando el campo album viene nulo en la respuesta del detalle
  - Al volver a la pantalla de agregar álbum, el álbum recién agregado no aparecía en "Mi colección actual": corregido persistiendo el estado actualizado en SavedStateHandle y recargando el
  detalle al volver

  Tests
  - Unit tests del ViewModel: estado inicial Loading→Ready, error de red, error de servidor, agregar exitoso (actualización optimista), fallo al agregar, filtro por búsqueda, retry
  - 7 pruebas E2E: apertura de pantalla, álbumes disponibles, colección actual, búsqueda sin resultados, selección de álbum muestra formulario, botón back, flujo completo

  ---
  HU15 — Agregar álbum a artista (músico)

  Funcionalidad implementada
  - Pantalla AddAlbumToMusicianScreen con búsqueda de álbumes disponibles y sección de discografía actual
  - Endpoint POST /musicians/{musicianId}/albums/{albumId} sin body (tap directo en "+" para agregar, sin formulario adicional)
  - Actualización optimista en el ViewModel con guard anti-doble-tap
  - Búsqueda con normalización NFD (insensible a mayúsculas y tildes)
  - Exclusión automática de álbumes ya en la discografía del artista
  - Navegación desde MusicianDetailScreen con botón "Agregar álbum" y regreso con refresco via RefreshMusicianDetailKey
  - Actualización best-effort del caché local Room tras el POST

  Tests
  - Unit tests del ViewModel: Loading→Ready, error de red, error de servidor, agregar exitoso, fallo en red al agregar (evento AddFailed emitido), filtro por nombre, retry
  - 6 pruebas E2E: apertura de pantalla, álbumes disponibles, discografía actual, filtro por búsqueda, tap "+" mueve álbum a discografía actual, botón back

  ---
  Ajustes UI adicionales
  
  - CollectorDetailScreen: título "ÁLBUMES COLECCIONADOS" escalado de labelSmall a labelMedium para armonizar visualmente con el botón
  - MusicianDetailScreen: título "Álbumes" escalado de titleMedium a titleLarge; portadas de álbumes reducidas de 120dp a 96dp y centradas con Arrangement.spacedBy(12.dp, 
  Alignment.CenterHorizontally) para que tres álbumes quepan sin recorte en pantalla estándar