### PR TITLE
feat(HU013): Crear premios — nueva sección Premios con listado y formulario de creación

### DIFF
--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakePrizeRepository.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakePrizeRepository.kt
@@ -1,0 +1,21 @@
+package com.misw4203.vinilos.di
+
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import javax.inject.Inject
+
+class FakePrizeRepository @Inject constructor() : PrizeRepository {
+
+    private val prizes = mutableListOf(
+        Prize(1, "Mejor Álbum Pop", "Academia Nacional de Artes", "Reconocimiento al mejor álbum de pop del año"),
+        Prize(2, "Grabación del Año", "Latin Recording Academy", "Premio a la mejor grabación del año en español"),
+    )
+
+    override suspend fun getPrizes(): List<Prize> = prizes.toList()
+
+    override suspend fun createPrize(name: String, description: String, organization: String): Prize {
+        val new = Prize(prizes.size + 1, name, description, organization)
+        prizes.add(new)
+        return new
+    }
+}

--- a/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/di/FakeRepositoryModule.kt
@@ -4,6 +4,7 @@ import com.misw4203.vinilos.domain.repository.AlbumRepository
 import com.misw4203.vinilos.domain.repository.BandRepository
 import com.misw4203.vinilos.domain.repository.CollectorRepository
 import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.repository.PrizeRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.components.SingletonComponent
@@ -32,4 +33,8 @@ abstract class FakeRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindBandRepository(impl: FakeBandRepository): BandRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrizeRepository(impl: FakePrizeRepository): PrizeRepository
 }

--- a/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreenTest.kt
+++ b/app/src/androidTest/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreenTest.kt
@@ -1,0 +1,206 @@
+package com.misw4203.vinilos.presentation.ui.screens.prize
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import com.misw4203.vinilos.domain.usecase.CreatePrizeUseCase
+import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
+import com.misw4203.vinilos.presentation.viewmodel.CreatePrizeViewModel
+import org.junit.Rule
+import org.junit.Test
+
+class CreatePrizeScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakePrizeRepo(
+        val prizes: List<Prize> = emptyList(),
+        private val shouldFailCreate: Boolean = false,
+    ) : PrizeRepository {
+        var lastCreated: Triple<String, String, String>? = null
+
+        override suspend fun getPrizes() = prizes
+
+        override suspend fun createPrize(name: String, description: String, organization: String): Prize {
+            if (shouldFailCreate) throw java.io.IOException("network error")
+            lastCreated = Triple(name, description, organization)
+            return Prize(99, name, description, organization)
+        }
+    }
+
+    private fun buildVm(repo: FakePrizeRepo) =
+        CreatePrizeViewModel(GetPrizesUseCase(repo), CreatePrizeUseCase(repo))
+
+    private fun launchScreen(vm: CreatePrizeViewModel, onSuccess: () -> Unit = {}) {
+        composeTestRule.setContent {
+            MaterialTheme {
+                CreatePrizeScreen(onBack = {}, onSuccess = onSuccess, viewModel = vm)
+            }
+        }
+    }
+
+    private fun waitForReady() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodesWithText("registered_prizes_section")
+                .fetchSemanticsNodes()
+                .isNotEmpty() ||
+                composeTestRule
+                    .onAllNodesWithTag("create_prize_name")
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+        }
+    }
+
+    // CA01 – form and prizes list section are visible
+    @Test
+    fun formAndRegisteredSectionAreVisible() {
+        val prizes = listOf(
+            Prize(1, "Grammy", "Music award", "NARAS"),
+            Prize(2, "Latin Grammy", "Latin music award", "Latin Recording Academy"),
+        )
+        val vm = buildVm(FakePrizeRepo(prizes))
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_name").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("create_prize_organization").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("create_prize_description").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("create_prize_submit").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("registered_prizes_section").assertIsDisplayed()
+    }
+
+    // CA04 – submit button disabled when fields empty
+    @Test
+    fun submitButtonDisabledWhenAllFieldsEmpty() {
+        val vm = buildVm(FakePrizeRepo())
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_submit").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_submit").assertIsNotEnabled()
+    }
+
+    @Test
+    fun submitButtonEnabledOnlyWhenAllFieldsFilled() {
+        val vm = buildVm(FakePrizeRepo())
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_submit").assertIsNotEnabled()
+
+        composeTestRule.onNodeWithTag("create_prize_name").performTextInput("Grammy")
+        composeTestRule.onNodeWithTag("create_prize_organization").performTextInput("NARAS")
+        composeTestRule.onNodeWithTag("create_prize_submit").assertIsNotEnabled()
+
+        composeTestRule.onNodeWithTag("create_prize_description").performTextInput("Top award in music")
+        composeTestRule.onNodeWithTag("create_prize_submit").assertIsEnabled()
+    }
+
+    // CA03 – successfully create a prize
+    @Test
+    fun submitWithAllFieldsCallsOnSuccess() {
+        val repo = FakePrizeRepo()
+        val vm = buildVm(repo)
+        var successCalled = false
+        launchScreen(vm, onSuccess = { successCalled = true })
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_name").performTextInput("Grammy")
+        composeTestRule.onNodeWithTag("create_prize_organization").performTextInput("NARAS")
+        composeTestRule.onNodeWithTag("create_prize_description").performTextInput("Top award in music")
+        composeTestRule.onNodeWithTag("create_prize_submit").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { successCalled }
+        assert(successCalled)
+    }
+
+    // CA10 – cancel with data shows confirmation dialog
+    @Test
+    fun cancelWithDataShowsConfirmationDialog() {
+        val vm = buildVm(FakePrizeRepo())
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_name").performTextInput("Grammy")
+        composeTestRule.onNodeWithTag("create_prize_cancel").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000) {
+            composeTestRule
+                .onAllNodesWithText("Descartar")
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Descartar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Seguir editando").assertIsDisplayed()
+    }
+
+    // CA10 – confirming cancel discards data
+    @Test
+    fun cancelConfirmedClearsForm() {
+        val vm = buildVm(FakePrizeRepo())
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_name").performTextInput("Grammy")
+        composeTestRule.onNodeWithTag("create_prize_cancel").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000) {
+            composeTestRule.onAllNodesWithTag("cancel_confirm_discard").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("cancel_confirm_discard").performClick()
+
+        // After discard the back callback fires (no crash means discard worked)
+    }
+
+    // CA10 – keeping editing leaves form intact
+    @Test
+    fun cancelDismissedKeepsFormData() {
+        val vm = buildVm(FakePrizeRepo())
+        launchScreen(vm)
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag("create_prize_name").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("create_prize_name").performTextInput("Grammy")
+        composeTestRule.onNodeWithTag("create_prize_cancel").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000) {
+            composeTestRule.onAllNodesWithTag("cancel_confirm_keep").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag("cancel_confirm_keep").performClick()
+
+        // Form is still visible with data, submit still enabled after refilling description
+        composeTestRule.onNodeWithTag("create_prize_name").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/api/VinilosApiService.kt
@@ -10,6 +10,7 @@ import com.misw4203.vinilos.data.remote.dto.CollectorDto
 import com.misw4203.vinilos.data.remote.dto.CommentDto
 import com.misw4203.vinilos.data.remote.dto.CreateCommentRequest
 import com.misw4203.vinilos.data.remote.dto.CreateAlbumRequestDto
+import com.misw4203.vinilos.data.remote.dto.CreatePrizeRequest
 import com.misw4203.vinilos.data.remote.dto.CreateTrackRequest
 import com.misw4203.vinilos.data.remote.dto.MusicianDetailDto
 import com.misw4203.vinilos.data.remote.dto.PrizeDetailDto
@@ -36,8 +37,14 @@ interface VinilosApiService {
     @GET("musicians/{id}")
     suspend fun getMusicianDetail(@Path("id") id: Int): MusicianDetailDto
 
+    @GET("prizes")
+    suspend fun getPrizes(): List<PrizeDetailDto>
+
     @GET("prizes/{id}")
     suspend fun getPrizeDetail(@Path("id") id: Int): PrizeDetailDto
+
+    @POST("prizes")
+    suspend fun createPrize(@Body body: CreatePrizeRequest): PrizeDetailDto
 
     @GET("collectors")
     suspend fun getCollectors(): List<CollectorDto>

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/CreatePrizeRequest.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/CreatePrizeRequest.kt
@@ -1,0 +1,9 @@
+package com.misw4203.vinilos.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class CreatePrizeRequest(
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String,
+    @SerializedName("organization") val organization: String,
+)

--- a/app/src/main/java/com/misw4203/vinilos/data/remote/dto/PrizeDetailDto.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/remote/dto/PrizeDetailDto.kt
@@ -1,11 +1,14 @@
 package com.misw4203.vinilos.data.remote.dto
 
 import com.google.gson.annotations.SerializedName
+import com.misw4203.vinilos.domain.model.Prize
 
 data class PrizeDetailDto(
     @SerializedName("id") val id: Int,
     @SerializedName("organization") val organization: String,
     @SerializedName("name") val name: String,
     @SerializedName("description") val description: String,
-    @SerializedName("performerPrizes") val performerPrizes: List<PerformerPrizeDto>
+    @SerializedName("performerPrizes") val performerPrizes: List<PerformerPrizeDto> = emptyList(),
 )
+
+fun PrizeDetailDto.toDomain() = Prize(id = id, name = name, description = description, organization = organization)

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/PrizeRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/PrizeRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.misw4203.vinilos.data.repository
 
 import com.misw4203.vinilos.data.remote.api.VinilosApiService
 import com.misw4203.vinilos.data.remote.dto.CreatePrizeRequest
+import com.misw4203.vinilos.data.remote.dto.toDomain
 import com.misw4203.vinilos.domain.model.Prize
 import com.misw4203.vinilos.domain.repository.PrizeRepository
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/misw4203/vinilos/data/repository/PrizeRepositoryImpl.kt
+++ b/app/src/main/java/com/misw4203/vinilos/data/repository/PrizeRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.misw4203.vinilos.data.repository
+
+import com.misw4203.vinilos.data.remote.api.VinilosApiService
+import com.misw4203.vinilos.data.remote.dto.CreatePrizeRequest
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class PrizeRepositoryImpl @Inject constructor(
+    private val api: VinilosApiService,
+) : PrizeRepository {
+
+    override suspend fun getPrizes(): List<Prize> = withContext(Dispatchers.IO) {
+        api.getPrizes().map { it.toDomain() }
+    }
+
+    override suspend fun createPrize(name: String, description: String, organization: String): Prize =
+        withContext(Dispatchers.IO) {
+            api.createPrize(CreatePrizeRequest(name, description, organization)).toDomain()
+        }
+}

--- a/app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/misw4203/vinilos/di/RepositoryModule.kt
@@ -4,10 +4,12 @@ import com.misw4203.vinilos.data.repository.AlbumRepositoryImpl
 import com.misw4203.vinilos.data.repository.BandRepositoryImpl
 import com.misw4203.vinilos.data.repository.CollectorRepositoryImpl
 import com.misw4203.vinilos.data.repository.MusicianRepositoryImpl
+import com.misw4203.vinilos.data.repository.PrizeRepositoryImpl
 import com.misw4203.vinilos.domain.repository.AlbumRepository
 import com.misw4203.vinilos.domain.repository.BandRepository
 import com.misw4203.vinilos.domain.repository.CollectorRepository
 import com.misw4203.vinilos.domain.repository.MusicianRepository
+import com.misw4203.vinilos.domain.repository.PrizeRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -33,4 +35,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindBandRepository(impl: BandRepositoryImpl): BandRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPrizeRepository(impl: PrizeRepositoryImpl): PrizeRepository
 }

--- a/app/src/main/java/com/misw4203/vinilos/domain/model/Prize.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/model/Prize.kt
@@ -1,0 +1,8 @@
+package com.misw4203.vinilos.domain.model
+
+data class Prize(
+    val id: Int,
+    val name: String,
+    val description: String,
+    val organization: String,
+)

--- a/app/src/main/java/com/misw4203/vinilos/domain/repository/PrizeRepository.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/repository/PrizeRepository.kt
@@ -1,0 +1,8 @@
+package com.misw4203.vinilos.domain.repository
+
+import com.misw4203.vinilos.domain.model.Prize
+
+interface PrizeRepository {
+    suspend fun getPrizes(): List<Prize>
+    suspend fun createPrize(name: String, description: String, organization: String): Prize
+}

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/CreatePrizeUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/CreatePrizeUseCase.kt
@@ -1,0 +1,12 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import javax.inject.Inject
+
+class CreatePrizeUseCase @Inject constructor(
+    private val repository: PrizeRepository,
+) {
+    suspend operator fun invoke(name: String, description: String, organization: String): Prize =
+        repository.createPrize(name, description, organization)
+}

--- a/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetPrizesUseCase.kt
+++ b/app/src/main/java/com/misw4203/vinilos/domain/usecase/GetPrizesUseCase.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.domain.usecase
+
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import javax.inject.Inject
+
+class GetPrizesUseCase @Inject constructor(
+    private val repository: PrizeRepository,
+) {
+    suspend operator fun invoke(): List<Prize> = repository.getPrizes()
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/Destinations.kt
@@ -42,6 +42,10 @@ object Destinations {
     const val AddAlbumMusicianArg = "musicianId"
     const val RefreshMusicianDetailKey = "refresh_musician_detail"
 
+    const val Prizes = "prizes"
+    const val CreatePrize = "prizes/create"
+    const val RefreshPrizesKey = "refresh_prizes"
+
     fun albumDetail(albumId: Long) = "album_detail/$albumId"
     fun collectorDetail(collectorId: Int) = "collector/$collectorId"
     fun addTrack(albumId: Long) = "album/$albumId/track/add"

--- a/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/navigation/VinilosNavHost.kt
@@ -37,6 +37,8 @@ import com.misw4203.vinilos.presentation.ui.screens.band.BandDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.collector.AddAlbumToCollectorScreen
 import com.misw4203.vinilos.presentation.ui.screens.collector.CollectorDetailScreen
 import com.misw4203.vinilos.presentation.ui.screens.collector.CollectorListScreen
+import com.misw4203.vinilos.presentation.ui.screens.prize.CreatePrizeScreen
+import com.misw4203.vinilos.presentation.ui.screens.prize.PrizeListScreen
 
 @Composable
 fun VinilosNavHost() {
@@ -50,6 +52,7 @@ fun VinilosNavHost() {
             currentRoute?.startsWith("artist/") == true ||
             currentRoute?.startsWith("band/") == true -> VinilosDestination.Artists
         currentRoute == Destinations.Collectors || currentRoute?.startsWith("collector/") == true -> VinilosDestination.Collectors
+        currentRoute == Destinations.Prizes || currentRoute == Destinations.CreatePrize -> VinilosDestination.Prizes
         else -> VinilosDestination.Albums
     }
 
@@ -63,6 +66,7 @@ fun VinilosNavHost() {
                         VinilosDestination.Albums -> Destinations.AlbumList
                         VinilosDestination.Artists -> Destinations.ArtistList
                         VinilosDestination.Collectors -> Destinations.Collectors
+                        VinilosDestination.Prizes -> Destinations.Prizes
                     }
                     navController.navigate(route) {
                         popUpTo(navController.graph.startDestinationId) { saveState = true }
@@ -261,6 +265,29 @@ fun VinilosNavHost() {
                             navController.previousBackStackEntry
                                 ?.savedStateHandle
                                 ?.set(Destinations.RefreshBandDetailKey, true)
+                            navController.popBackStack()
+                        },
+                    )
+                }
+                composable(Destinations.Prizes) { entry ->
+                    val refreshFlag by entry.savedStateHandle
+                        .getStateFlow(Destinations.RefreshPrizesKey, false)
+                        .collectAsStateWithLifecycle()
+                    PrizeListScreen(
+                        onCreatePrize = { navController.navigate(Destinations.CreatePrize) },
+                        refreshKey = refreshFlag,
+                        onRefreshHandled = {
+                            entry.savedStateHandle[Destinations.RefreshPrizesKey] = false
+                        },
+                    )
+                }
+                composable(Destinations.CreatePrize) {
+                    CreatePrizeScreen(
+                        onBack = { navController.popBackStack() },
+                        onSuccess = {
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(Destinations.RefreshPrizesKey, true)
                             navController.popBackStack()
                         },
                     )

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/components/VinilosBottomNav.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.PersonSearch
 import androidx.compose.material3.Icon
@@ -36,7 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import com.misw4203.vinilos.R
 
-enum class VinilosDestination { Albums, Artists, Collectors }
+enum class VinilosDestination { Albums, Artists, Collectors, Prizes }
 
 @Composable
 fun VinilosBottomNav(
@@ -74,6 +76,13 @@ fun VinilosBottomNav(
             active = selected == VinilosDestination.Collectors,
             onClick = { onSelect(VinilosDestination.Collectors) },
             modifier = Modifier.testTag("bottom_nav_collectors"),
+        )
+        NavTab(
+            label = stringResource(R.string.nav_prizes),
+            icon = if (selected == VinilosDestination.Prizes) Icons.Filled.EmojiEvents else Icons.Outlined.EmojiEvents,
+            active = selected == VinilosDestination.Prizes,
+            onClick = { onSelect(VinilosDestination.Prizes) },
+            modifier = Modifier.testTag("bottom_nav_prizes"),
         )
     }
 }

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreen.kt
@@ -1,0 +1,363 @@
+package com.misw4203.vinilos.presentation.ui.screens.prize
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.EmojiEvents
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.viewmodel.CreatePrizeUiState
+import com.misw4203.vinilos.presentation.viewmodel.CreatePrizeViewModel
+
+private const val MAX_NAME_LENGTH = 100
+private const val MAX_ORG_LENGTH = 100
+private const val MAX_DESC_LENGTH = 500
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreatePrizeScreen(
+    onBack: () -> Unit,
+    onSuccess: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CreatePrizeViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    var name by rememberSaveable { mutableStateOf("") }
+    var organization by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
+
+    var showCancelDialog by remember { mutableStateOf(false) }
+
+    val hasUnsavedChanges = name.isNotBlank() || organization.isNotBlank() || description.isNotBlank()
+    val isSubmitting = uiState is CreatePrizeUiState.Submitting
+    val existingPrizes = (uiState as? CreatePrizeUiState.Ready)?.existingPrizes ?: emptyList()
+
+    val successMessage = stringResource(R.string.create_prize_success)
+    val retryLabel = stringResource(android.R.string.ok)
+
+    LaunchedEffect(uiState) {
+        when (val state = uiState) {
+            is CreatePrizeUiState.Success -> {
+                onSuccess()
+                viewModel.resetState()
+            }
+            is CreatePrizeUiState.Error -> {
+                val result = snackbarHostState.showSnackbar(
+                    message = state.message,
+                    actionLabel = "Reintentar",
+                    duration = SnackbarDuration.Long,
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    viewModel.submit(name, description, organization)
+                } else {
+                    viewModel.resetState()
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    val navigateBack: () -> Unit = {
+        if (hasUnsavedChanges) showCancelDialog = true else onBack()
+    }
+
+    BackHandler(enabled = hasUnsavedChanges) {
+        showCancelDialog = true
+    }
+
+    if (showCancelDialog) {
+        AlertDialog(
+            onDismissRequest = { showCancelDialog = false },
+            title = { Text(stringResource(R.string.create_prize_cancel_confirm_title)) },
+            text = { Text(stringResource(R.string.create_prize_cancel_confirm_body)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCancelDialog = false
+                        name = ""
+                        organization = ""
+                        description = ""
+                        onBack()
+                    },
+                    modifier = Modifier.testTag("cancel_confirm_discard"),
+                ) {
+                    Text("Descartar")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showCancelDialog = false },
+                    modifier = Modifier.testTag("cancel_confirm_keep"),
+                ) {
+                    Text("Seguir editando")
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.create_prize_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.semantics { heading() },
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navigateBack,
+                        modifier = Modifier.testTag("create_prize_back_button"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                ),
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            // Form card
+            Card(
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                ),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f)),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = stringResource(R.string.create_prize_title).uppercase(),
+                            style = MaterialTheme.typography.headlineSmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.semantics { heading() },
+                        )
+                    }
+
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { if (it.length <= MAX_NAME_LENGTH) name = it },
+                        label = { Text(stringResource(R.string.create_prize_field_name)) },
+                        supportingText = { Text("${name.length}/$MAX_NAME_LENGTH") },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        singleLine = true,
+                        enabled = !isSubmitting,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("create_prize_name"),
+                    )
+
+                    OutlinedTextField(
+                        value = organization,
+                        onValueChange = { if (it.length <= MAX_ORG_LENGTH) organization = it },
+                        label = { Text(stringResource(R.string.create_prize_field_organization)) },
+                        supportingText = { Text("${organization.length}/$MAX_ORG_LENGTH") },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                        singleLine = true,
+                        enabled = !isSubmitting,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("create_prize_organization"),
+                    )
+
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { if (it.length <= MAX_DESC_LENGTH) description = it },
+                        label = { Text(stringResource(R.string.create_prize_field_description)) },
+                        supportingText = { Text("${description.length}/$MAX_DESC_LENGTH") },
+                        minLines = 4,
+                        maxLines = 6,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        enabled = !isSubmitting,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("create_prize_description"),
+                    )
+
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+
+                    Column(
+                        modifier = Modifier.padding(top = 4.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Button(
+                            onClick = { viewModel.submit(name, description, organization) },
+                            enabled = name.isNotBlank() && organization.isNotBlank() && description.isNotBlank() && !isSubmitting,
+                            shape = RoundedCornerShape(50),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.onSurface,
+                                contentColor = MaterialTheme.colorScheme.surface,
+                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(56.dp)
+                                .testTag("create_prize_submit"),
+                        ) {
+                            AnimatedVisibility(visible = isSubmitting) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(18.dp),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.surface,
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                }
+                            }
+                            Icon(
+                                imageVector = Icons.Outlined.EmojiEvents,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = if (isSubmitting) stringResource(R.string.create_prize_saving)
+                                else stringResource(R.string.create_prize_save),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                        }
+
+                        OutlinedButton(
+                            onClick = navigateBack,
+                            enabled = !isSubmitting,
+                            shape = RoundedCornerShape(50),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(56.dp)
+                                .testTag("create_prize_cancel"),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.action_cancel),
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Existing prizes list section
+            RegisteredPrizesSection(uiState = uiState, existingPrizes = existingPrizes)
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun RegisteredPrizesSection(
+    uiState: CreatePrizeUiState,
+    existingPrizes: List<Prize>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = stringResource(R.string.create_prize_registered).uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            letterSpacing = androidx.compose.ui.unit.TextUnit(0.12f, androidx.compose.ui.unit.TextUnitType.Em),
+            modifier = Modifier
+                .semantics { heading() }
+                .testTag("registered_prizes_section"),
+        )
+
+        when (uiState) {
+            is CreatePrizeUiState.LoadingPrizes -> LoadingState(modifier = Modifier.height(80.dp))
+            else -> {
+                if (existingPrizes.isEmpty()) {
+                    Text(
+                        text = "No hay premios registrados aún.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    existingPrizes.forEach { prize ->
+                        PrizeCard(
+                            prize = prize,
+                            modifier = Modifier.testTag("registered_prize_${prize.id}"),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/CreatePrizeScreen.kt
@@ -188,7 +188,7 @@ fun CreatePrizeScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 20.dp),
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             // Form card
@@ -206,10 +206,15 @@ fun CreatePrizeScreen(
                 ) {
                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         Text(
-                            text = stringResource(R.string.create_prize_title).uppercase(),
+                            text = stringResource(R.string.create_prize_section_title),
                             style = MaterialTheme.typography.headlineSmall,
                             color = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.semantics { heading() },
+                        )
+                        Text(
+                            text = stringResource(R.string.create_prize_section_subtitle),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/PrizeListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/PrizeListScreen.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.EmojiEvents
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -109,7 +110,7 @@ fun PrizeListScreen(
             contentColor = MaterialTheme.colorScheme.onPrimary,
         ) {
             Icon(
-                imageVector = Icons.Outlined.EmojiEvents,
+                imageVector = Icons.Outlined.Add,
                 contentDescription = stringResource(R.string.cd_create_prize),
             )
         }
@@ -122,7 +123,7 @@ internal fun PrizeCard(
     modifier: Modifier = Modifier,
 ) {
     androidx.compose.material3.Card(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         colors = androidx.compose.material3.CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         ),

--- a/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/PrizeListScreen.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/ui/screens/prize/PrizeListScreen.kt
@@ -1,0 +1,150 @@
+package com.misw4203.vinilos.presentation.ui.screens.prize
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.EmojiEvents
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import com.misw4203.vinilos.R
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.presentation.ui.components.EmptyState
+import com.misw4203.vinilos.presentation.ui.components.ErrorState
+import com.misw4203.vinilos.presentation.ui.components.ListCounter
+import com.misw4203.vinilos.presentation.ui.components.LoadingState
+import com.misw4203.vinilos.presentation.ui.components.VinilosTopBar
+import com.misw4203.vinilos.presentation.viewmodel.PrizesUiState
+import com.misw4203.vinilos.presentation.viewmodel.PrizesViewModel
+
+@Composable
+fun PrizeListScreen(
+    onCreatePrize: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PrizesViewModel = hiltViewModel(),
+    refreshKey: Boolean = false,
+    onRefreshHandled: () -> Unit = {},
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewModel.refresh()
+        }
+    }
+
+    LaunchedEffect(refreshKey) {
+        if (refreshKey) {
+            viewModel.refresh()
+            onRefreshHandled()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            VinilosTopBar(title = stringResource(R.string.prizes_title))
+            when (val state = uiState) {
+                is PrizesUiState.Loading -> LoadingState(modifier = Modifier.testTag("prizes_loading"))
+                is PrizesUiState.Error -> ErrorState(
+                    onRetry = viewModel::retry,
+                    isNetworkError = state.isNetworkError,
+                )
+                is PrizesUiState.Empty -> EmptyState(modifier = Modifier.testTag("prizes_empty"))
+                is PrizesUiState.Success -> LazyColumn(
+                    modifier = Modifier.testTag("prizes_list"),
+                    contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    item {
+                        ListCounter(
+                            text = pluralStringResource(
+                                R.plurals.prizes_record_count,
+                                state.prizes.size,
+                                state.prizes.size,
+                            ),
+                            testTag = "prizes_record_count",
+                        )
+                    }
+                    items(state.prizes, key = { it.id }) { prize ->
+                        PrizeCard(
+                            prize = prize,
+                            modifier = Modifier.testTag("prize_card_${prize.id}"),
+                        )
+                    }
+                    item { Spacer(Modifier.size(80.dp)) }
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onCreatePrize,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(24.dp)
+                .testTag("create_prize_fab"),
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.EmojiEvents,
+                contentDescription = stringResource(R.string.cd_create_prize),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun PrizeCard(
+    prize: Prize,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.material3.Card(
+        modifier = modifier,
+        colors = androidx.compose.material3.CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+        border = androidx.compose.foundation.BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            androidx.compose.material3.Text(
+                text = prize.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            androidx.compose.material3.Text(
+                text = prize.organization,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeUiState.kt
@@ -1,0 +1,11 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Prize
+
+sealed interface CreatePrizeUiState {
+    data object LoadingPrizes : CreatePrizeUiState
+    data class Ready(val existingPrizes: List<Prize>) : CreatePrizeUiState
+    data object Submitting : CreatePrizeUiState
+    data object Success : CreatePrizeUiState
+    data class Error(val message: String) : CreatePrizeUiState
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
@@ -44,6 +44,11 @@ class CreatePrizeViewModel @Inject constructor(
     }
 
     fun submit(name: String, description: String, organization: String) {
+        if (name.isBlank() || organization.isBlank() || description.isBlank()) {
+            _uiState.value = CreatePrizeUiState.Error("Todos los campos son obligatorios.")
+            return
+        }
+
         val current = _uiState.value
         val existingPrizes = if (current is CreatePrizeUiState.Ready) current.existingPrizes else emptyList()
 

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
@@ -2,6 +2,7 @@ package com.misw4203.vinilos.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.model.Prize
 import com.misw4203.vinilos.domain.usecase.CreatePrizeUseCase
 import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModel.kt
@@ -1,0 +1,80 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.CreatePrizeUseCase
+import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class CreatePrizeViewModel @Inject constructor(
+    private val getPrizes: GetPrizesUseCase,
+    private val createPrize: CreatePrizeUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<CreatePrizeUiState>(CreatePrizeUiState.LoadingPrizes)
+    val uiState: StateFlow<CreatePrizeUiState> = _uiState.asStateFlow()
+
+    init {
+        loadPrizes()
+    }
+
+    fun loadPrizes() {
+        _uiState.value = CreatePrizeUiState.LoadingPrizes
+        viewModelScope.launch {
+            _uiState.value = try {
+                CreatePrizeUiState.Ready(getPrizes())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                CreatePrizeUiState.Ready(emptyList())
+            } catch (e: Exception) {
+                CreatePrizeUiState.Ready(emptyList())
+            }
+        }
+    }
+
+    fun submit(name: String, description: String, organization: String) {
+        val current = _uiState.value
+        val existingPrizes = if (current is CreatePrizeUiState.Ready) current.existingPrizes else emptyList()
+
+        if (isDuplicate(name, organization, existingPrizes)) {
+            _uiState.value = CreatePrizeUiState.Error("Ya existe un premio con ese nombre y organización.")
+            return
+        }
+
+        _uiState.value = CreatePrizeUiState.Submitting
+        viewModelScope.launch {
+            _uiState.value = try {
+                createPrize(name.trim(), description.trim(), organization.trim())
+                CreatePrizeUiState.Success
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                CreatePrizeUiState.Error("Sin conexión a internet. Inténtalo de nuevo.")
+            } catch (e: HttpException) {
+                CreatePrizeUiState.Error("Error del servidor (${e.code()}). Verifica los datos.")
+            } catch (e: Exception) {
+                CreatePrizeUiState.Error("Ocurrió un error inesperado.")
+            }
+        }
+    }
+
+    fun resetState() {
+        loadPrizes()
+    }
+
+    private fun isDuplicate(name: String, organization: String, prizes: List<Prize>): Boolean =
+        prizes.any {
+            it.name.trim().equals(name.trim(), ignoreCase = true) &&
+                it.organization.trim().equals(organization.trim(), ignoreCase = true)
+        }
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/PrizesUiState.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/PrizesUiState.kt
@@ -1,0 +1,10 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import com.misw4203.vinilos.domain.model.Prize
+
+sealed interface PrizesUiState {
+    data object Loading : PrizesUiState
+    data class Success(val prizes: List<Prize>) : PrizesUiState
+    data object Empty : PrizesUiState
+    data class Error(val isNetworkError: Boolean) : PrizesUiState
+}

--- a/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/PrizesViewModel.kt
+++ b/app/src/main/java/com/misw4203/vinilos/presentation/viewmodel/PrizesViewModel.kt
@@ -1,0 +1,47 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+
+@HiltViewModel
+class PrizesViewModel @Inject constructor(
+    private val getPrizes: GetPrizesUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<PrizesUiState>(PrizesUiState.Loading)
+    val uiState: StateFlow<PrizesUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() = load()
+
+    fun refresh() = load()
+
+    private fun load() {
+        _uiState.value = PrizesUiState.Loading
+        viewModelScope.launch {
+            _uiState.value = try {
+                val prizes = getPrizes()
+                if (prizes.isEmpty()) PrizesUiState.Empty else PrizesUiState.Success(prizes)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                PrizesUiState.Error(isNetworkError = true)
+            } catch (e: Exception) {
+                PrizesUiState.Error(isNetworkError = false)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,10 +211,12 @@
     </plurals>
 
     <!-- HU013 - Premios -->
-    <string name="nav_prizes">Premios</string>
+    <string name="nav_prizes">Prizes</string>
     <string name="prizes_title">Premios</string>
     <string name="cd_create_prize">Crear premio</string>
     <string name="create_prize_title">Crear Premio</string>
+    <string name="create_prize_section_title">Nuevo Premio</string>
+    <string name="create_prize_section_subtitle">Completa la información para registrar un nuevo premio en el catálogo.</string>
     <string name="create_prize_field_name">Nombre del premio</string>
     <string name="create_prize_field_organization">Organización que otorga</string>
     <string name="create_prize_field_description">Descripción</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,4 +209,25 @@
         <item quantity="one">%d álbum en la discografía</item>
         <item quantity="other">%d álbumes en la discografía</item>
     </plurals>
+
+    <!-- HU013 - Premios -->
+    <string name="nav_prizes">Premios</string>
+    <string name="prizes_title">Premios</string>
+    <string name="cd_create_prize">Crear premio</string>
+    <string name="create_prize_title">Crear Premio</string>
+    <string name="create_prize_field_name">Nombre del premio</string>
+    <string name="create_prize_field_organization">Organización que otorga</string>
+    <string name="create_prize_field_description">Descripción</string>
+    <string name="create_prize_save">Guardar Premio</string>
+    <string name="create_prize_saving">Guardando…</string>
+    <string name="create_prize_success">Premio creado correctamente</string>
+    <string name="create_prize_error_duplicate">Ya existe un premio con ese nombre y organización</string>
+    <string name="create_prize_registered">Premios registrados</string>
+    <string name="create_prize_cancel_confirm_title">¿Descartar cambios?</string>
+    <string name="create_prize_cancel_confirm_body">Los datos ingresados se perderán.</string>
+    <string name="prize_create_cta">Crear Premio</string>
+    <plurals name="prizes_record_count">
+        <item quantity="one">%d premio</item>
+        <item quantity="other">%d premios</item>
+    </plurals>
 </resources>

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/CreatePrizeViewModelTest.kt
@@ -1,0 +1,267 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import com.misw4203.vinilos.domain.usecase.CreatePrizeUseCase
+import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreatePrizeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakePrizeRepository(
+        var prizesResult: Result<List<Prize>> = Result.success(emptyList()),
+        var createResult: Result<Prize> = Result.success(
+            Prize(99, "Grammy", "A music award", "NARAS")
+        ),
+    ) : PrizeRepository {
+        var createCallCount = 0
+        override suspend fun getPrizes() = prizesResult.getOrThrow()
+        override suspend fun createPrize(name: String, description: String, organization: String): Prize {
+            createCallCount++
+            return createResult.getOrThrow()
+        }
+    }
+
+    private fun buildViewModel(repo: FakePrizeRepository) =
+        CreatePrizeViewModel(GetPrizesUseCase(repo), CreatePrizeUseCase(repo))
+
+    private fun httpError(code: Int = 400) = HttpException(
+        Response.error<Any>(code, "".toResponseBody("text/plain".toMediaType()))
+    )
+
+    // ── Prizes list loading ────────────────────────────────────────────────
+
+    @Test
+    fun `starts in LoadingPrizes then emits Ready with prizes`() = runTest {
+        val prizes = listOf(Prize(1, "Grammy", "Desc", "NARAS"))
+        val repo = FakePrizeRepository(prizesResult = Result.success(prizes))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Ready)
+            assertEquals(1, (state as CreatePrizeUiState.Ready).existingPrizes.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when prizes load fails gracefully falls back to Ready with empty list`() = runTest {
+        val repo = FakePrizeRepository(prizesResult = Result.failure(IOException()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Ready)
+            assertEquals(0, (state as CreatePrizeUiState.Ready).existingPrizes.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Successful submission ──────────────────────────────────────────────
+
+    @Test
+    fun `submit with valid fields emits Submitting then Success`() = runTest {
+        val repo = FakePrizeRepository()
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "Top award", "NARAS")
+            assertEquals(CreatePrizeUiState.Submitting, awaitItem())
+            advanceUntilIdle()
+            assertEquals(CreatePrizeUiState.Success, awaitItem())
+            assertEquals(1, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Required field validation (CA04) ──────────────────────────────────
+
+    @Test
+    fun `submit with blank name emits Error without calling API`() = runTest {
+        val repo = FakePrizeRepository()
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("", "Desc", "Org")
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertEquals(0, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `submit with blank organization emits Error without calling API`() = runTest {
+        val repo = FakePrizeRepository()
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "Desc", "")
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertEquals(0, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `submit with blank description emits Error without calling API`() = runTest {
+        val repo = FakePrizeRepository()
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "", "NARAS")
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertEquals(0, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Duplicate detection (CA06) ─────────────────────────────────────────
+
+    @Test
+    fun `submit with duplicate name and organization emits Error without calling API`() = runTest {
+        val existing = listOf(Prize(1, "Grammy", "A music award", "NARAS"))
+        val repo = FakePrizeRepository(prizesResult = Result.success(existing))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready with existing prizes
+
+            viewModel.submit("Grammy", "Any description", "NARAS")
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertTrue((state as CreatePrizeUiState.Error).message.contains("ya existe", ignoreCase = true))
+            assertEquals(0, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `duplicate check is case-insensitive`() = runTest {
+        val existing = listOf(Prize(1, "grammy", "A music award", "naras"))
+        val repo = FakePrizeRepository(prizesResult = Result.success(existing))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("GRAMMY", "Any description", "NARAS")
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertEquals(0, repo.createCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Network and server errors (CA07) ──────────────────────────────────
+
+    @Test
+    fun `submit with IOException emits Error with network message`() = runTest {
+        val repo = FakePrizeRepository(createResult = Result.failure(IOException()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "Desc", "NARAS")
+            assertEquals(CreatePrizeUiState.Submitting, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertTrue((state as CreatePrizeUiState.Error).message.contains("conexión", ignoreCase = true))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `submit with HttpException emits Error with server message`() = runTest {
+        val repo = FakePrizeRepository(createResult = Result.failure(httpError(400)))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "Desc", "NARAS")
+            assertEquals(CreatePrizeUiState.Submitting, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is CreatePrizeUiState.Error)
+            assertTrue((state as CreatePrizeUiState.Error).message.contains("servidor", ignoreCase = true))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `error state is set before resetState call allowing form data preservation`() = runTest {
+        val repo = FakePrizeRepository(createResult = Result.failure(IOException()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            awaitItem() // Ready
+
+            viewModel.submit("Grammy", "Desc", "NARAS")
+            assertEquals(CreatePrizeUiState.Submitting, awaitItem())
+            advanceUntilIdle()
+            val errorState = awaitItem()
+            assertTrue(errorState is CreatePrizeUiState.Error)
+
+            // resetState reloads prizes without clearing form (form lives in the UI)
+            viewModel.resetState()
+            assertEquals(CreatePrizeUiState.LoadingPrizes, awaitItem())
+            advanceUntilIdle()
+            val recovered = awaitItem()
+            assertTrue(recovered is CreatePrizeUiState.Ready)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/PrizesViewModelTest.kt
+++ b/app/src/test/java/com/misw4203/vinilos/presentation/viewmodel/PrizesViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.misw4203.vinilos.presentation.viewmodel
+
+import app.cash.turbine.test
+import com.misw4203.vinilos.MainDispatcherRule
+import com.misw4203.vinilos.domain.model.Prize
+import com.misw4203.vinilos.domain.repository.PrizeRepository
+import com.misw4203.vinilos.domain.usecase.CreatePrizeUseCase
+import com.misw4203.vinilos.domain.usecase.GetPrizesUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrizesViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private class FakePrizeRepository(
+        var prizesResult: Result<List<Prize>> = Result.success(emptyList()),
+        var createResult: Result<Prize> = Result.success(samplePrize()),
+    ) : PrizeRepository {
+        var getPrizesCallCount = 0
+        override suspend fun getPrizes(): List<Prize> {
+            getPrizesCallCount++
+            return prizesResult.getOrThrow()
+        }
+        override suspend fun createPrize(name: String, description: String, organization: String) =
+            createResult.getOrThrow()
+    }
+
+    private fun buildViewModel(repo: FakePrizeRepository) =
+        PrizesViewModel(GetPrizesUseCase(repo))
+
+    @Test
+    fun `starts in Loading then emits Success when prizes load`() = runTest {
+        val prizes = listOf(samplePrize())
+        val repo = FakePrizeRepository(prizesResult = Result.success(prizes))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(PrizesUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is PrizesUiState.Success)
+            assertEquals(1, (state as PrizesUiState.Success).prizes.size)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits Empty when repository returns empty list`() = runTest {
+        val repo = FakePrizeRepository(prizesResult = Result.success(emptyList()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(PrizesUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(PrizesUiState.Empty, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emits network Error when repository throws IOException`() = runTest {
+        val repo = FakePrizeRepository(prizesResult = Result.failure(IOException()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(PrizesUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(PrizesUiState.Error(isNetworkError = true), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `retry reloads prizes and recovers to Success`() = runTest {
+        val repo = FakePrizeRepository(prizesResult = Result.failure(IOException()))
+        val viewModel = buildViewModel(repo)
+
+        viewModel.uiState.test {
+            assertEquals(PrizesUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            assertEquals(PrizesUiState.Error(isNetworkError = true), awaitItem())
+
+            repo.prizesResult = Result.success(listOf(samplePrize()))
+            viewModel.retry()
+
+            assertEquals(PrizesUiState.Loading, awaitItem())
+            advanceUntilIdle()
+            val state = awaitItem()
+            assertTrue(state is PrizesUiState.Success)
+            assertEquals(2, repo.getPrizesCallCount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    companion object {
+        fun samplePrize() = Prize(id = 1, name = "Grammy", description = "A music award", organization = "NARAS")
+    }
+}


### PR DESCRIPTION
## Resumen

Implementación completa de **HU013 — Crear premios**, que habilita a los coleccionistas a registrar nuevos premios en el catálogo de Vinilos.

## Cambios incluidos

### Arquitectura (Clean Architecture + MVVM)
- **Data layer**: `CreatePrizeRequest` DTO, extensión `toDomain()` en `PrizeDetailDto`, `PrizeRepositoryImpl` (red, sin caché local), nuevos endpoints `GET /prizes` y `POST /prizes` en `VinilosApiService`, binding Hilt en `RepositoryModule`
- **Domain layer**: modelo `Prize`, interfaz `PrizeRepository`, `GetPrizesUseCase`, `CreatePrizeUseCase`
- **Presentation layer**: `PrizesViewModel` + `PrizesUiState`, `CreatePrizeViewModel` + `CreatePrizeUiState`

### Pantallas
- **`PrizeListScreen`**: destino del 4.º tab; lista de premios con tarjetas a ancho completo y FAB "+" para navegar a la creación
- **`CreatePrizeScreen`**: formulario con contadores de caracteres (CA05), botón deshabilitado con campos vacíos (CA04), diálogo de confirmación al cancelar con datos (CA10), lista de premios registrados al pie para referencia y detección de duplicados (CA06)

### Navegación
- 4.º tab **Prizes** en la barra inferior
- Rutas `prizes` y `prizes/create` con señal de refresco vía `savedStateHandle`

### Criterios de aceptación cubiertos
| CA | Descripción | Cobertura |
|---|---|---|
| CA01 | Listado de premios + botón crear visibles | Pantalla PrizeList |
| CA03 | Crear premio exitosamente | Test UI + flujo manual |
| CA04 | Validación campos obligatorios | VM (blank check) + botón deshabilitado en UI |
| CA05 | Contadores y límites de caracteres | UI (maxLength 100/100/500) |
| CA06 | Prevención de duplicados | VM (check case-insensitive antes de llamar API) |
| CA07 | Manejo de error de red/servidor | IOException vs HttpException + Snackbar con "Reintentar" |
| CA08 | Visibilidad para todos los usuarios | Lista recargada tras creación |
| CA09 | Restricción de rol | Sin auth activa (patrón DefaultCollectorId) |
| CA10 | Cancelación con confirmación | AlertDialog + BackHandler |

## Pruebas

### Unitarias (`CreatePrizeViewModelTest`, `PrizesViewModelTest`) — 12 tests
- Carga de lista: Loading → Ready / Empty / Error
- Envío exitoso (CA03)
- Campos en blanco (CA04)
- Detección de duplicados case-insensitive (CA06)
- Errores de red y servidor con mensajes distintos (CA07)
- Preservación de datos del formulario tras error (CA07)

### Instrumentadas (`CreatePrizeScreenTest`) — 6 tests
- Formulario y sección de premios registrados visibles (CA01)
- Botón deshabilitado/habilitado según estado de campos (CA04)
- Envío exitoso dispara `onSuccess` (CA03)
- Cancelar con datos muestra diálogo de confirmación (CA10)
- Confirmar descarte y descartar con "Seguir editando" (CA10)

## Test plan

- [ ] Abrir tab Prizes → lista de premios carga correctamente
- [ ] FAB (+) navega al formulario de creación
- [ ] Dejar campos vacíos → botón "Guardar Premio" deshabilitado
- [ ] Llenar los 3 campos → botón habilitado → crear → aparece en la lista
- [ ] Intentar crear premio con nombre+organización duplicado → mensaje de error
- [ ] Llenar campo(s) → Cancelar → aparece diálogo de confirmación
- [ ] Confirmar cancelación → regresa a lista sin crear premio
- [ ] Sin conexión → mensaje de error + opción Reintentar